### PR TITLE
Integrate flux cube tool into runner

### DIFF
--- a/SED_tools.py
+++ b/SED_tools.py
@@ -552,10 +552,11 @@ def menu() -> str:
     print("  1) Spectra (SVO / MSG / MAST)")
     print("  2) Filters (SVO)")
     print("  3) Rebuild (lookup + HDF5 + flux cube)")
+    print("  4) Flux cube inspector / photometry")
     print("  0) Quit")
     choice = input("> ").strip()
     mapping = {
-        "1": "spectra", "2": "filters", "3": "rebuild",
+        "1": "spectra", "2": "filters", "3": "rebuild", "4": "fluxcube",
         "0": "quit"
     }
     return mapping.get(choice, "")

--- a/run.py
+++ b/run.py
@@ -17,6 +17,7 @@ REQUIRED = {
     "h5py":              "h5py>=3.10",
     "astropy":           "astropy>=6.0",
     "astroquery":        "astroquery>=0.4.7",
+    "matplotlib":        "matplotlib>=3.7",
 }
 
 THIS_DIR = os.path.abspath(os.path.dirname(__file__))
@@ -28,6 +29,8 @@ TOOLS = {
     "regen":      os.path.join(THIS_DIR, "svo_regen_spectra_lookup.py"),
     "flux":       os.path.join(THIS_DIR, "precompute_flux_cube.py"),
     "lookfilter": os.path.join(THIS_DIR, "svo_spectra_filter.py"),
+    "fluxcube":   os.path.join(THIS_DIR, "flux_cube_tool.py"),
+    "flux-tool":  os.path.join(THIS_DIR, "flux_cube_tool.py"),
 }
 
 def in_venv() -> bool:
@@ -149,6 +152,8 @@ def main():
                              workers=5,
                              force_bundle_h5=True,
                              build_flux_cube=True)
+        elif choice == "fluxcube":
+            run_tool("fluxcube")
         else:
             exit()
 


### PR DESCRIPTION
## Summary
- add the flux cube inspection tool to the run.py launcher and menu
- extend flux_cube_tool with interactive discovery of flux_cube.bin files and single-point grid handling
- ensure dependencies include matplotlib and gracefully ignore trailing cube data

## Testing
- `python -m compileall flux_cube_tool.py`
- `python flux_cube_tool.py --flux-cube flux_cube.bin --teff 3500 --logg 4.0 --metallicity 0 --plot /tmp/test.png --save-sed /tmp/test.txt --filters`


------
https://chatgpt.com/codex/tasks/task_e_68f00931b4408321957bbbcfef5be667