### PR TITLE
Expose configurable data directory defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
+# SED Tools
 
+## Data locations
+
+The tools and Python APIs now write their outputs to `./data` at the repository
+root by default (for example `./data/stellar_models`). To change where data is
+stored, set one of the environment variables before running a command:
+
+- `SED_DATA_DIR` to change the base `./data` directory for both filters and
+  stellar models at once.
+- `SED_STELLAR_DIR` or `SED_FILTER_DIR` to override either location
+  individually.
+
+The resolved paths are also exposed programmatically as
+`sed_tools.DATA_DIR_DEFAULT`, `sed_tools.STELLAR_DIR_DEFAULT`, and
+`sed_tools.FILTER_DIR_DEFAULT` to make them easy to inspect or override in
+code.

--- a/sed_tools/__init__.py
+++ b/sed_tools/__init__.py
@@ -41,6 +41,7 @@ from .models import (
     EvaluatedSED,
     PhotometryResult,
     ModelMatch,
+    DATA_DIR_DEFAULT,
     STELLAR_DIR_DEFAULT,
     FILTER_DIR_DEFAULT,
 )
@@ -414,6 +415,7 @@ __all__ = [
     "EvaluatedSED",
     "PhotometryResult",
     "ModelMatch",
+    "DATA_DIR_DEFAULT",
     "STELLAR_DIR_DEFAULT",
     "FILTER_DIR_DEFAULT",
     "find_atmospheres",

--- a/sed_tools/cli.py
+++ b/sed_tools/cli.py
@@ -36,11 +36,7 @@ from .mast_spectra_grabber import MASTSpectraGrabber
 import h5py
 import numpy as np
 from .spectra_cleaner import clean_model_dir
-
-
-BASE_DIR = os.path.dirname(os.path.dirname(__file__))
-STELLAR_DIR_DEFAULT = os.path.normpath(os.path.join(BASE_DIR, "data", "stellar_models"))
-FILTER_DIR_DEFAULT = os.path.normpath(os.path.join(BASE_DIR, "data", "filters"))
+from .models import STELLAR_DIR_DEFAULT, FILTER_DIR_DEFAULT
 
 # ------------ small utils ------------
 

--- a/sed_tools/models.py
+++ b/sed_tools/models.py
@@ -27,11 +27,14 @@ Number = Union[int, float, np.floating]
 FilterSpec = Union[str, os.PathLike[str], FilterCurve, Tuple[str, Union[str, os.PathLike[str]]]]
 
 PACKAGE_ROOT = Path(__file__).resolve().parent
+DATA_DIR_DEFAULT = Path(
+    os.environ.get("SED_DATA_DIR", PACKAGE_ROOT.parent / "data")
+).expanduser()
 STELLAR_DIR_DEFAULT = Path(
-    os.environ.get("SED_STELLAR_DIR", PACKAGE_ROOT / "data" / "stellar_models")
+    os.environ.get("SED_STELLAR_DIR", DATA_DIR_DEFAULT / "stellar_models")
 ).expanduser()
 FILTER_DIR_DEFAULT = Path(
-    os.environ.get("SED_FILTER_DIR", PACKAGE_ROOT / "data" / "filters")
+    os.environ.get("SED_FILTER_DIR", DATA_DIR_DEFAULT / "filters")
 ).expanduser()
 
 


### PR DESCRIPTION
## Summary
- default data directories now resolve to the repository-level `./data` folder instead of `./sed_tools/data`
- expose the resolved data, stellar, and filter directories via exported constants for easy customization
- document environment variables for overriding the default storage locations

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f82c81db48321a399a58e98be49f6)