### PR TITLE
Remove .bak backup file handling from spectra cleaning workflow

### DIFF
--- a/sed_tools/__init__.py
+++ b/sed_tools/__init__.py
@@ -221,7 +221,7 @@ def run_rebuild_flow(base_dir: str = STELLAR_DIR_DEFAULT,
         # 0) CLEAN FIRST (fix λ<=0, repair index grids via HDF5 when possible)
         if clean_model_dir:
             try:
-                summary = clean_model_dir(model_dir, try_h5_recovery=True, backup=True, rebuild_lookup=True)
+                summary = clean_model_dir(model_dir, try_h5_recovery=True, rebuild_lookup=True)
                 print(f"[clean] {model_name}: total={summary['total']}, "
                       f"fixed={len(summary['fixed'])}, recovered={len(summary['recovered'])}, "
                       f"skipped={len(summary['skipped'])}, deleted={len(summary['deleted'])}")
@@ -333,7 +333,7 @@ def run_spectra_flow(
         n_written = g.download_model_spectra(name, meta)
         print(f"[{src}] wrote {n_written} spectra -> {model_dir}")
 
-        summary = clean_model_dir(model_dir, try_h5_recovery=True, backup=True, rebuild_lookup=True)
+        summary = clean_model_dir(model_dir, try_h5_recovery=True, rebuild_lookup=True)
         print(f"[clean] total={summary['total']} fixed={len(summary['fixed'])} "
               f"recovered={len(summary['recovered'])} skipped={len(summary['skipped'])} "
               f"deleted={len(summary['deleted'])}")

--- a/sed_tools/api.py
+++ b/sed_tools/api.py
@@ -671,7 +671,7 @@ class SED:
         model_dir = base_dir / catalog
         if clean:
             from .spectra_cleaner import clean_model_dir
-            summary = clean_model_dir(str(model_dir), try_h5_recovery=True, backup=True, rebuild_lookup=True)
+            summary = clean_model_dir(str(model_dir), try_h5_recovery=True, rebuild_lookup=True)
             n_fixed = len(summary.get('fixed', []))
             n_total = summary.get('total', 0)
             print(f"[fetch] Cleaned: {n_total} total, {n_fixed} fixed")

--- a/sed_tools/cli.py
+++ b/sed_tools/cli.py
@@ -445,7 +445,7 @@ def run_rebuild_flow(
         print(f"[rebuild] {model_name}")
         model_dir = os.path.join(base_dir, model_name)
 
-        summary = clean_model_dir(model_dir, try_h5_recovery=True, backup=True, rebuild_lookup=True)
+        summary = clean_model_dir(model_dir, try_h5_recovery=True, rebuild_lookup=True)
         print(f"[clean] {model_name}: total={summary['total']}")
 
         txts = glob.glob(os.path.join(model_dir, "*.txt"))
@@ -689,7 +689,7 @@ def run_spectra_flow(
             continue
 
         # --- Cleaning ---
-        summary = clean_model_dir(model_dir, try_h5_recovery=True, backup=True, rebuild_lookup=True)
+        summary = clean_model_dir(model_dir, try_h5_recovery=True, rebuild_lookup=True)
         
         # ─────────────────────────────────────────────────────────────
         # DETAILED REPORTING

--- a/sed_tools/spectra_cleaner.py
+++ b/sed_tools/spectra_cleaner.py
@@ -608,18 +608,8 @@ def write_standardized_spectrum(
     flux: np.ndarray,
     meta: SpectrumMeta,
     unit_info: UnitInfo,
-    backup: bool = True
 ) -> None:
     """Write standardized spectrum with proper header."""
-    
-    # Create backup if requested
-    if backup:
-        backup_path = filepath + '.bak'
-        if not os.path.exists(backup_path):
-            try:
-                os.rename(filepath, backup_path)
-            except Exception:
-                pass
     
     # Build header
     header = STANDARD_HEADER_TEMPLATE.format(
@@ -748,7 +738,6 @@ def clean_spectrum_file(
     filepath: str,
     catalog_units: Optional[UnitInfo] = None,
     try_h5_recovery: bool = True,
-    backup: bool = True
 ) -> Tuple[str, str]:
     """
     Clean and standardize a single spectrum file.
@@ -758,7 +747,6 @@ def clean_spectrum_file(
         catalog_units: Pre-determined units for the catalog (from 10% sample).
                        If None, detects units per-file (legacy behavior).
         try_h5_recovery: Attempt HDF5 wavelength recovery for index grids
-        backup: Create .bak backup file
     
     Returns: (status, detail)
         status: 'skipped_already', 'skipped_index', 'skipped_invalid', 
@@ -837,7 +825,7 @@ def clean_spectrum_file(
         return 'skipped_invalid', f'validation failed: {msg}'
     
     # Write standardized file
-    write_standardized_spectrum(filepath, wl_std, flux_std, meta, unit_info, backup=backup)
+    write_standardized_spectrum(filepath, wl_std, flux_std, meta, unit_info)
     
     detail = f"{wl_std[0]:.0f}-{wl_std[-1]:.0f}Å, {unit_info.wavelength_unit}→Å, conf={unit_info.confidence}"
     return status, detail
@@ -896,7 +884,6 @@ def rebuild_lookup_table(model_dir: str) -> str:
 def clean_model_dir(
     model_dir: str,
     try_h5_recovery: bool = True,
-    backup: bool = True,
     rebuild_lookup: bool = True,
     sample_fraction: float = 0.10
 ) -> Dict:
@@ -908,7 +895,6 @@ def clean_model_dir(
     Args:
         model_dir: Directory containing *.txt spectrum files
         try_h5_recovery: Attempt HDF5 wavelength recovery for index grids
-        backup: Create .bak files before modifying
         rebuild_lookup: Rebuild lookup_table.csv after cleaning
         sample_fraction: Fraction of files to sample for unit detection (default 10%)
     
@@ -969,7 +955,6 @@ def clean_model_dir(
                 filepath,
                 catalog_units=catalog_units,
                 try_h5_recovery=try_h5_recovery,
-                backup=backup
             )
             if status in summary:
                 summary[status].append(filename)


### PR DESCRIPTION
### Motivation
- Remove automatic `.bak` backup creation and related options so spectrum files are written in-place without producing `.bak` files.
- Simplify the cleaning API by eliminating an extra `backup` parameter and associated branching in the write path.

### Description
- Deleted backup creation logic from `write_standardized_spectrum` so files are always written in-place and removed the `backup` parameter from its signature.
- Removed the `backup` parameter from `clean_spectrum_file` and `clean_model_dir` and updated their docstrings to no longer reference backup behavior.
- Updated all call sites to stop passing `backup=True`, including calls from `sed_tools/cli.py`, `sed_tools/api.py`, and `sed_tools/__init__.py` so the cleaner is invoked without backup flags.
- Adjusted the in-file wiring so `clean_model_dir` calls `clean_spectrum_file` and `write_standardized_spectrum` without any backup-related arguments.

### Testing
- Ran a code search for remaining `.bak` or backup-related occurrences in the modified modules and found no remaining references in the touched files, which confirms removal of the backup surface.
- Compiled the modified modules with `python -m compileall sed_tools/spectra_cleaner.py sed_tools/cli.py sed_tools/api.py sed_tools/__init__.py` and it completed successfully with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a72d7da10c832199411e093a390b36)