### PR TITLE
Enable bulk filter downloads for multiple facilities

### DIFF
--- a/sed_tools/cli.py
+++ b/sed_tools/cli.py
@@ -825,6 +825,32 @@ def run_spectra_flow(
 
 
 
+def _parse_multi_selection(spec: str, total: int) -> list[int]:
+    """Parse 1-based IDs like "1,3-5" into unique 0-based indexes."""
+    chosen: set[int] = set()
+    for chunk in (part.strip() for part in spec.split(",")):
+        if not chunk:
+            continue
+        if "-" in chunk:
+            bounds = [part.strip() for part in chunk.split("-", 1)]
+            if len(bounds) != 2 or not bounds[0].isdigit() or not bounds[1].isdigit():
+                raise ValueError(f"Invalid range: {chunk}")
+            start, end = int(bounds[0]), int(bounds[1])
+            if start > end:
+                start, end = end, start
+            if start < 1 or end > total:
+                raise ValueError(f"Range out of bounds: {chunk}")
+            chosen.update(range(start - 1, end))
+            continue
+        if not chunk.isdigit():
+            raise ValueError(f"Invalid item: {chunk}")
+        value = int(chunk)
+        if value < 1 or value > total:
+            raise ValueError(f"Selection out of bounds: {value}")
+        chosen.add(value - 1)
+    return sorted(chosen)
+
+
 def run_filters_flow(base_dir: str = str(FILTER_DIR_DEFAULT)) -> None:
     """
     Interactive filter downloader with automatic NJMSVO fallback.
@@ -852,17 +878,75 @@ def run_filters_flow(base_dir: str = str(FILTER_DIR_DEFAULT)) -> None:
     
     # Facility selection loop
     while True:
+        bulk_spec = input(
+            "Bulk telescope mode: enter facility IDs (e.g. 1,3-5) to download ALL instruments, "
+            "or press Enter for single-facility mode: "
+        ).strip()
+
+        if bulk_spec:
+            try:
+                facility_indexes = _parse_multi_selection(bulk_spec, len(facilities))
+            except ValueError as exc:
+                print(f"Invalid selection: {exc}")
+                continue
+            if not facility_indexes:
+                print("No facilities selected.")
+                continue
+
+            selected_facilities = [facilities[i] for i in facility_indexes]
+            confirm = input(
+                f"Download ALL instruments for {len(selected_facilities)} selected facilities? [Y/n] "
+            ).strip().lower()
+            if confirm and not confirm.startswith('y'):
+                continue
+
+            for facility in selected_facilities:
+                instruments = svo.list_instruments(facility.key)
+
+                if not instruments:
+                    print(f"No instruments found for {facility.label}.")
+                    continue
+
+                print(f"\n{facility.label}: {len(instruments)} instruments")
+                for instrument in instruments:
+                    filters = svo.list_filters(facility.key, instrument.key)
+
+                    if not filters:
+                        print(f"  [skip] {instrument.label}: no filters found")
+                        continue
+
+                    downloaded = False
+                    if njm_available:
+                        njm_facilities = njm.discover_facilities()
+                        if facility.key in njm_facilities:
+                            njm_instruments = njm.discover_instruments(facility.key)
+                            if instrument.key in njm_instruments:
+                                print(f"  [njm] Downloading {instrument.label}...")
+                                count = njm.download_filters(facility.key, instrument.key)
+                                if count > 0:
+                                    print(f"  [njm] Downloaded {count} filters")
+                                    downloaded = True
+
+                    if not downloaded:
+                        print(f"  [svo] Downloading {instrument.label} ({len(filters)} filters)...")
+                        svo.download_filters(filters)
+
+            again = input("\nBulk download another set of facilities? [y/N] ").strip().lower()
+            if again.startswith('y'):
+                continue
+            return
+
         fac_idx = _prompt_choice(facilities, "Filter Facilities")
         if fac_idx is None:
             return
-        
+
         facility = facilities[fac_idx]
         instruments = svo.list_instruments(facility.key)
-        
+
         if not instruments:
             print(f"No instruments found for {facility.label}.")
             continue
-        
+
         # Instrument selection loop
         while True:
             inst_idx = _prompt_choice(
@@ -870,30 +954,30 @@ def run_filters_flow(base_dir: str = str(FILTER_DIR_DEFAULT)) -> None:
                 f"Instruments for {facility.label}",
                 allow_back=True
             )
-            
+
             if inst_idx is None:
                 return
             if inst_idx == -1:
                 break  # Back to facilities
-            
+
             instrument = instruments[inst_idx]
             filters = svo.list_filters(facility.key, instrument.key)
-            
+
             if not filters:
                 print(f"No filters found for {instrument.label}.")
                 continue
-            
+
             # Show selection
             print(f"\n{facility.label} / {instrument.label}")
             print(f"Found {len(filters)} filters")
-            
+
             confirm = input("Download all filters? [Y/n] ").strip().lower()
             if confirm and not confirm.startswith('y'):
                 continue
-            
+
             # Smart download: Try NJM first, fall back to SVO
             downloaded = False
-            
+
             if njm_available:
                 # Check if NJM has this facility/instrument
                 njm_facilities = njm.discover_facilities()
@@ -906,13 +990,13 @@ def run_filters_flow(base_dir: str = str(FILTER_DIR_DEFAULT)) -> None:
                         if count > 0:
                             print(f"[njm]  Downloaded {count} filters")
                             downloaded = True
-            
+
             # Fall back to SVO if NJM didn't work
             if not downloaded:
                 print(f"\n[svo] Downloading from SVO...")
                 svo.download_filters(filters)
                 print(f"[svo]  Downloaded {len(filters)} filters")
-            
+
             again = input("\nDownload another instrument? [y/N] ").strip().lower()
             if not again.startswith('y'):
                 break

--- a/sed_tools/svo_filter_grabber.py
+++ b/sed_tools/svo_filter_grabber.py
@@ -7,7 +7,7 @@ import sys
 import textwrap
 import urllib.parse
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Sequence
+from typing import Dict, List, Optional, Sequence, Set
 
 import requests
 from astroquery.svo_fps import SvoFps
@@ -242,6 +242,34 @@ def _clean_filename(value: str) -> str:
     return _clean_path(value).replace(" ", "_")
 
 
+def parse_multi_selection(spec: str, total: int) -> List[int]:
+    """Parse a 1-based comma-separated/range selection into unique 0-based indices."""
+    chosen: Set[int] = set()
+    for chunk in (part.strip() for part in spec.split(",")):
+        if not chunk:
+            continue
+        if "-" in chunk:
+            bounds = [p.strip() for p in chunk.split("-", 1)]
+            if len(bounds) != 2 or not bounds[0].isdigit() or not bounds[1].isdigit():
+                raise ValueError(f"Invalid range: {chunk}")
+            start, end = int(bounds[0]), int(bounds[1])
+            if start > end:
+                start, end = end, start
+            if start < 1 or end > total:
+                raise ValueError(f"Range out of bounds: {chunk}")
+            chosen.update(range(start - 1, end))
+            continue
+
+        if not chunk.isdigit():
+            raise ValueError(f"Invalid item: {chunk}")
+        value = int(chunk)
+        if value < 1 or value > total:
+            raise ValueError(f"Selection out of bounds: {value}")
+        chosen.add(value - 1)
+
+    return sorted(chosen)
+
+
 
 
 def run_interactive(base_dir: str = DEFAULT_BASE_DIR) -> None:
@@ -253,7 +281,44 @@ def run_interactive(base_dir: str = DEFAULT_BASE_DIR) -> None:
         return
 
     while True:
-        
+        bulk_spec = input(
+            "Bulk telescope mode: enter facility IDs (e.g. 1,3-5) to download ALL instruments, "
+            "or press Enter for single-facility mode: "
+        ).strip()
+        if bulk_spec:
+            try:
+                facility_indexes = parse_multi_selection(bulk_spec, len(facilities))
+            except ValueError as exc:
+                print(f"Invalid selection: {exc}")
+                continue
+            if not facility_indexes:
+                print("No facilities selected.")
+                continue
+
+            selected = [facilities[i] for i in facility_indexes]
+            print(f"Selected {len(selected)} facilities for bulk download.")
+            confirm = input("Download ALL instruments for selected facilities? [Y/n] ").strip().lower()
+            if confirm and not confirm.startswith("y"):
+                continue
+
+            for facility in selected:
+                instruments = browser.list_instruments(facility.key)
+                if not instruments:
+                    print(f"No instruments found for {facility.label}.")
+                    continue
+                print(f"\nFacility: {facility.label} ({len(instruments)} instruments)")
+                for instrument in instruments:
+                    filters = browser.list_filters(facility.key, instrument.key)
+                    if not filters:
+                        print(f"  [skip] {instrument.label}: no filters found")
+                        continue
+                    print(f"  Downloading {len(filters)} filters for {instrument.label}")
+                    browser.download_filters(filters)
+            again = input("Bulk download another set of facilities? [y/N] ").strip().lower()
+            if again.startswith("y"):
+                continue
+            return
+
         fac_idx = _prompt_choice(facilities, "Facilities")
 
         if fac_idx is None:

--- a/tests/test_filter_bulk_selection.py
+++ b/tests/test_filter_bulk_selection.py
@@ -1,0 +1,16 @@
+from sed_tools.cli import _parse_multi_selection
+from sed_tools.svo_filter_grabber import parse_multi_selection
+
+
+def test_parse_multi_selection_accepts_ranges_and_ids() -> None:
+    assert parse_multi_selection("1,3-5,5", 6) == [0, 2, 3, 4]
+    assert _parse_multi_selection("2-1,4", 5) == [0, 1, 3]
+
+
+def test_parse_multi_selection_rejects_out_of_bounds() -> None:
+    try:
+        parse_multi_selection("7", 6)
+    except ValueError as exc:
+        assert "out of bounds" in str(exc).lower()
+    else:
+        raise AssertionError("Expected ValueError")


### PR DESCRIPTION
### Motivation
- Allow users to request bulk downloading of filters across multiple telescopes/facilities in one operation. 
- When bulk mode is used, the intent is to download filters for ALL instruments under each selected facility.

### Description
- Added a selection parser `parse_multi_selection` in `sed_tools/svo_filter_grabber.py` and `_parse_multi_selection` in `sed_tools/cli.py` to accept 1-based comma/range specs like `1,3-5` and return unique 0-based indices with validation and de-duplication. 
- Added a bulk prompt to the SVO interactive flow (`run_interactive`) so users can enter facility IDs to trigger bulk downloads that iterate all instruments for each selected facility and download their filters. 
- Added the same bulk selection prompt and handling to the CLI `run_filters_flow` path with per-instrument NJM-first fallback preserved. 
- Added unit tests `tests/test_filter_bulk_selection.py` to exercise range/ID parsing and bounds checks.

### Testing
- Ran the new unit tests with `PYTHONPATH=. pytest -q tests/test_filter_bulk_selection.py`, which passed (`2 passed`).
- Verified syntax by running `python -m py_compile sed_tools/svo_filter_grabber.py sed_tools/cli.py`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a72dae7828832198b9eb5c6c6b8ed8)