### PR TITLE
Refactor IO/UI helpers, add io_utils module, expose CLI shims, and add IO tests

### DIFF
--- a/jupyter_notebooks/08_filters.ipynb
+++ b/jupyter_notebooks/08_filters.ipynb
@@ -6,14 +6,14 @@
    "source": [
     "# 08 — Photometric Filters\n",
     "\n",
-    "This notebook demonstrates how to download and manage photometric filter transmission curves from the SVO Filter Profile Service.\n",
+    "This notebook demonstrates how to download and manage photometric filter transmission curves. `Filters.fetch()` tries the NJM mirror first when it has the requested data, then falls back to the SVO Filter Profile Service.\n",
     "\n",
     "**Key class:** `Filters`\n",
     "\n",
     "Downloaded filters are stored in the directory structure expected by MESA's colors module:\n",
     "```\n",
     "data/filters/<Facility>/<Instrument>/<Band>.dat\n",
-    "```"
+    "```\n"
    ]
   },
   {
@@ -22,10 +22,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from pathlib import Path\n",
+    "from collections import Counter\n",
+    "\n",
     "from sed_tools.api import Filters, SED\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
-    "import os"
+    "import os\n"
    ]
   },
   {
@@ -34,7 +37,7 @@
    "source": [
     "## 1. Querying Available Filters\n",
     "\n",
-    "`Filters.query()` lists filter sets available from SVO and locally. Each entry represents one facility/instrument combination."
+    "`Filters.query()` lists locally installed filters and remote facilities. Local entries include an instrument name and `n_filters`; remote entries may be facility-level catalogue entries from SVO or the NJM mirror.\n"
    ]
   },
   {
@@ -58,15 +61,16 @@
     }
    ],
    "source": [
-    "# All available filter sets (includes remote SVO)\n",
+    "# All available filter entries (local + remote SVO/NJM)\n",
     "all_filters = Filters.query()\n",
-    "print(f\"Total filter sets: {len(all_filters)}\")\n",
+    "print(f\"Total filter entries: {len(all_filters)}\")\n",
+    "print(\"By source:\", dict(Counter(f.get(\"source\", \"local\") for f in all_filters)))\n",
     "\n",
-    "# Locally installed only\n",
+    "# Locally installed only. Empty/partial directories are ignored.\n",
     "local_filters = Filters.query(include_remote=False)\n",
     "print(f\"Locally installed: {len(local_filters)}\")\n",
     "for f in local_filters:\n",
-    "    print(f\"  {f['facility']}/{f['instrument']}: {f.get('n_filters', '?')} filters\")"
+    "    print(f\"  {f['facility']}/{f['instrument']}: {f.get('n_filters', '?')} filters\")\n"
    ]
   },
   {
@@ -103,7 +107,9 @@
    "source": [
     "## 2. Downloading Filters\n",
     "\n",
-    "`Filters.fetch(facility, instrument)` downloads the transmission curves and returns the path to the directory. Pass positional arguments — facility first, then instrument."
+    "`Filters.fetch(facility, instrument)` downloads the transmission curves and returns the path to the directory. It uses an existing complete local copy if present, otherwise tries NJM first and falls back to SVO. A download is accepted only when real `.dat` files are present.\n",
+    "\n",
+    "Pass positional arguments — facility first, then instrument.\n"
    ]
   },
   {
@@ -126,16 +132,17 @@
    ],
    "source": [
     "# Download Johnson broadband filters\n",
-    "path = Filters.fetch('Generic', 'Johnson')\n",
-    "print(f\"Downloaded to: {path}\")\n",
+    "johnson_path = Filters.fetch('Generic', 'Johnson')\n",
+    "print(f\"Johnson downloaded to: {johnson_path}\")\n",
     "\n",
-    "# Download Gaia DR3 passbands\n",
-    "path = Filters.fetch('GAIA', 'GAIA')\n",
-    "print(f\"Downloaded to: {path}\")\n",
+    "# Download Gaia passbands\n",
+    "gaia_path = Filters.fetch('GAIA', 'GAIA')\n",
+    "print(f\"Gaia downloaded to: {gaia_path}\")\n",
     "\n",
-    "# Download LSST filters\n",
-    "path = Filters.fetch('LSST', 'LSST')\n",
-    "print(f\"Downloaded to: {path}\")"
+    "# Download WISE filters. This is a good smoke test for NJM → SVO fallback.\n",
+    "wise_path = Filters.fetch('WISE', 'WISE')\n",
+    "print(f\"WISE downloaded to: {wise_path}\")\n",
+    "print(\"WISE files:\", sorted(p.name for p in Path(wise_path).glob(\"*.dat\")))\n"
    ]
   },
   {
@@ -166,21 +173,27 @@
    "source": [
     "def load_filter(path):\n",
     "    \"\"\"Load a two-column filter transmission file.\"\"\"\n",
-    "    data = np.loadtxt(path, delimiter=',', skiprows=1)\n",
+    "    path = Path(path)\n",
+    "    try:\n",
+    "        data = np.loadtxt(path, delimiter=',', skiprows=1)\n",
+    "    except ValueError:\n",
+    "        data = np.loadtxt(path, comments='#')\n",
     "    return data[:, 0], data[:, 1]  # wavelength (Å), transmission\n",
+    "\n",
     "\n",
     "def plot_filters(filter_dir, title='Filter transmission curves'):\n",
     "    \"\"\"Plot all .dat files in a filter directory.\"\"\"\n",
-    "    dat_files = sorted(f for f in os.listdir(filter_dir) if f.endswith('.dat'))\n",
+    "    filter_dir = Path(filter_dir)\n",
+    "    dat_files = sorted(filter_dir.glob('*.dat'))\n",
     "    if not dat_files:\n",
     "        print(f\"No .dat files found in {filter_dir}\")\n",
     "        return\n",
     "\n",
     "    fig, ax = plt.subplots(figsize=(10, 5))\n",
     "    cmap = plt.get_cmap('tab10')\n",
-    "    for i, fname in enumerate(dat_files[2:]):\n",
-    "        wl, trans = load_filter(os.path.join(filter_dir, fname))\n",
-    "        band = os.path.splitext(fname)[0]\n",
+    "    for i, path in enumerate(dat_files):\n",
+    "        wl, trans = load_filter(path)\n",
+    "        band = path.stem\n",
     "        ax.plot(wl, trans, lw=1.5, label=band, color=cmap(i % 10))\n",
     "\n",
     "    ax.set_xlabel('Wavelength (Å)')\n",
@@ -192,8 +205,7 @@
     "    plt.show()\n",
     "\n",
     "\n",
-    "# Example — uncomment after downloading Johnson filters:\n",
-    "plot_filters('../data/filters/Generic/Johnson', title='Johnson broadband filters')"
+    "plot_filters(johnson_path, title='Johnson broadband filters')\n"
    ]
   },
   {
@@ -224,17 +236,15 @@
    "source": [
     "def list_mesa_filter_names(filter_dir):\n",
     "    \"\"\"Print the MESA reference name for each filter in a directory.\"\"\"\n",
-    "    if not os.path.isdir(filter_dir):\n",
+    "    filter_dir = Path(filter_dir)\n",
+    "    if not filter_dir.is_dir():\n",
     "        print(f\"Directory not found: {filter_dir}\")\n",
     "        return\n",
-    "    for fname in sorted(os.listdir(filter_dir)):\n",
-    "        if fname.endswith('.dat'):\n",
-    "            stem = os.path.splitext(fname)[0]\n",
-    "            print(f\"  File: {fname}  →  MESA reference: '{stem}'\")\n",
+    "    for path in sorted(filter_dir.glob('*.dat')):\n",
+    "        print(f\"  File: {path.name}  →  MESA reference: '{path.stem}'\")\n",
     "\n",
     "\n",
-    "# Example:\n",
-    "list_mesa_filter_names('../data/filters/GAIA/GAIA')"
+    "list_mesa_filter_names(gaia_path)\n"
    ]
   },
   {

--- a/jupyter_notebooks/09_synthetic_photometry.ipynb
+++ b/jupyter_notebooks/09_synthetic_photometry.ipynb
@@ -21,9 +21,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from pathlib import Path\n",
+    "\n",
     "from sed_tools.api import SED, Filters\n",
+    "from sed_tools.models import STELLAR_DIR_DEFAULT\n",
     "import matplotlib.pyplot as plt\n",
-    "import numpy as np"
+    "import numpy as np\n"
    ]
   },
   {
@@ -32,7 +35,7 @@
    "source": [
     "## 1. Setup — Load a Catalog and Filters\n",
     "\n",
-    "Filters are identified by their filename stem only (e.g. `\"G\"` for `GAIA/GAIA/G.dat`). Ensure the relevant filter set is downloaded before calling `photometry()`."
+    "Filters are identified by their filename stem only (e.g. `\"G\"` for `GAIA/GAIA/G.dat`). `Filters.fetch()` returns the actual installed directory, so use that path instead of hard-coding a local checkout path.\n"
    ]
   },
   {
@@ -67,9 +70,11 @@
     "except Exception as e:\n",
     "    print(f\"Catalog not available: {e}\")\n",
     "\n",
-    "# Download Gaia and Johnson filters if not already present:\n",
-    "Filters.fetch('GAIA', 'GAIA')\n",
-    "Filters.fetch('Generic', 'Johnson')"
+    "# Download filters if not already present and keep the returned paths.\n",
+    "gaia_dir = Filters.fetch('GAIA', 'GAIA')\n",
+    "johnson_dir = Filters.fetch('Generic', 'Johnson')\n",
+    "print(f\"Gaia filters: {gaia_dir}\")\n",
+    "print(f\"Johnson filters: {johnson_dir}\")\n"
    ]
   },
   {
@@ -99,10 +104,10 @@
     "if 'sed' in locals():\n",
     "    spectrum = sed(teff=5777, logg=4.44, metallicity=0.0)\n",
     "\n",
-    "    phot = spectrum.photometry('Grp', 'BP', 'RP', system='AB')\n",
+    "    phot = spectrum.photometry('G', 'Gbp', 'Grp', system='AB')\n",
     "\n",
     "    for band, result in phot.items():\n",
-    "        print(f\"  {band:4s}: {result.magnitude:.4f} AB mag\")"
+    "        print(f\"  {band:4s}: {result.magnitude:.4f} AB mag\")\n"
    ]
   },
   {
@@ -131,22 +136,31 @@
     }
    ],
    "source": [
-    "from pathlib import Path\n",
-    "\n",
     "if 'sed' in locals():\n",
-    "    V_path = Path(\"/home/njm/SED_Tools/data/filters/Generic/Johnson/V.dat\")\n",
-    "    B_path = Path(\"/home/njm/SED_Tools/data/filters/Generic/Johnson/B.dat\")\n",
-    "    vega_path = Path(\"/home/njm/SED_Tools/data/stellar_models/vega_sed.txt\")\n",
+    "    V_path = Path(johnson_dir) / \"V.dat\"\n",
+    "    B_path = Path(johnson_dir) / \"B.dat\"\n",
     "\n",
-    "    phot_vega = spectrum.photometry(\n",
-    "        V_path,\n",
-    "        B_path,\n",
-    "        system=\"Vega\",\n",
-    "        vega_spectrum=vega_path\n",
-    "    )\n",
+    "    vega_candidates = [\n",
+    "        STELLAR_DIR_DEFAULT / \"vega_flam.csv\",\n",
+    "        STELLAR_DIR_DEFAULT / \"vega_sed.txt\",\n",
+    "    ]\n",
+    "    vega_path = next((p for p in vega_candidates if p.exists()), None)\n",
     "\n",
-    "    for band, result in phot_vega.items():\n",
-    "        print(f\"  {band}: {result.magnitude:.4f} Vega mag\")"
+    "    if vega_path is None:\n",
+    "        print(\"No Vega reference spectrum found; skipping Vega example.\")\n",
+    "        print(\"Checked:\")\n",
+    "        for p in vega_candidates:\n",
+    "            print(f\"  {p}\")\n",
+    "    else:\n",
+    "        phot_vega = spectrum.photometry(\n",
+    "            V_path,\n",
+    "            B_path,\n",
+    "            system=\"Vega\",\n",
+    "            vega_spectrum=vega_path,\n",
+    "        )\n",
+    "\n",
+    "        for band, result in phot_vega.items():\n",
+    "            print(f\"  {band}: {result.magnitude:.4f} Vega mag\")\n"
    ]
   },
   {
@@ -228,13 +242,11 @@
     }
    ],
    "source": [
-    "from pathlib import Path\n",
-    "\n",
     "if 'sed' in locals():\n",
     "    subset = sed.cat.filter(teff_min=4000, teff_max=10000, logg_min=4.0)\n",
     "    print(f\"Computing photometry for {len(subset)} spectra...\")\n",
     "\n",
-    "    gaia_dir = Path.home() / \"SED_Tools\" / \"data\" / \"filters\" / \"GAIA\" / \"GAIA\"\n",
+    "    gaia_dir = Path(gaia_dir)\n",
     "    G_path   = gaia_dir / \"G.dat\"\n",
     "    Gbp_path = gaia_dir / \"Gbp.dat\"\n",
     "    Grp_path = gaia_dir / \"Grp.dat\"\n",
@@ -263,7 +275,7 @@
     "    ax.set_title(\"Synthetic Gaia CMD (main sequence, [M/H]=all)\")\n",
     "    ax.grid(True, alpha=0.3)\n",
     "    plt.tight_layout()\n",
-    "    plt.show()"
+    "    plt.show()\n"
    ]
   },
   {

--- a/jupyter_notebooks/10_flux_cubes_and_mesa.ipynb
+++ b/jupyter_notebooks/10_flux_cubes_and_mesa.ipynb
@@ -209,11 +209,11 @@
    "source": [
     "## 5. MESA Integration\n",
     "\n",
-    "Once you have a `flux_cube.bin` and `lookup_table.csv`, wire them into MESA by copying or symlinking into MESA's colors data directory.\n",
+    "Once you have a `flux_cube.bin` and `lookup_table.csv`, wire them into MESA's colors data directory.\n",
     "\n",
-    "### Directory Structure Expected by MESA\n",
+    "### Directory Structure Expected by the colors module\n",
     "```\n",
-    "$MESA_DIR/colors/data/stellar_models/Kurucz2003all/\n",
+    "$MESA_DIR/data/colors_data/stellar_models/Kurucz2003all/\n",
     "    flux_cube.bin\n",
     "    lookup_table.csv\n",
     "    Kurucz2003all.h5   (optional)\n",
@@ -222,21 +222,23 @@
     "### Symlinking (recommended for development)\n",
     "```bash\n",
     "ln -s $(pwd)/data/stellar_models/Kurucz2003all \\\n",
-    "      $MESA_DIR/colors/data/stellar_models/Kurucz2003all\n",
+    "      $MESA_DIR/data/colors_data/stellar_models/Kurucz2003all\n",
     "```\n",
     "\n",
-    "### MESA Inlist\n",
+    "### MESA colors inlist\n",
     "```fortran\n",
-    "&controls\n",
-    "    use_atm_for_photosphere = .true.\n",
-    "    atm_option = 'table'\n",
-    "    atm_table = 'Kurucz2003all'\n",
+    "&colors\n",
+    "    use_colors = .true.\n",
+    "    stellar_atm = '/data/colors_data/stellar_models/Kurucz2003all/'\n",
+    "    instrument = '/data/colors_data/filters/GAIA/GAIA'\n",
+    "    vega_sed = '/data/colors_data/stellar_models/vega_flam.csv'\n",
+    "    mag_system = 'Vega'\n",
     "/\n",
     "```\n",
     "\n",
     "### Filter Reference\n",
     "\n",
-    "MESA identifies filters by the filename stem only. For `data/filters/GAIA/GAIA/G.dat`, use `\"G\"` in the inlist."
+    "MESA identifies filters by the filename stem only. For `data/colors_data/filters/GAIA/GAIA/G.dat`, use `\"G\"` in the inlist/history output.\n"
    ]
   },
   {
@@ -275,11 +277,11 @@
     "local_catalogs = SED.query(include_remote=False)\n",
     "mesa_dir = os.environ.get('MESA_DIR', '/path/to/mesa')\n",
     "\n",
-    "print(\"# Symlink commands for MESA integration:\")\n",
+    "print(\"# Symlink commands for MESA colors integration:\")\n",
     "for c in local_catalogs:\n",
     "    src = os.path.join(str(SED._model_root), c.name)\n",
-    "    dst = os.path.join(mesa_dir, 'colors', 'data', 'stellar_models', c.name)\n",
-    "    print(f\"ln -s {src} {dst}\")"
+    "    dst = os.path.join(mesa_dir, 'data', 'colors_data', 'stellar_models', c.name)\n",
+    "    print(f\"ln -s {src} {dst}\")\n"
    ]
   },
   {

--- a/sed_tools/__init__.py
+++ b/sed_tools/__init__.py
@@ -1,526 +1,78 @@
-"""High level API for working with pre-computed stellar SED libraries.
-
-This module exposes the :class:`SED` facade together with helper classes that
-wrap the existing command line tooling in a programmatic friendly interface.
-Users can discover locally available model grids, load a specific grid into
-memory and evaluate spectra or synthetic photometry directly from Python code.
-
-Typical usage::
-
-    from sed_tools import SED
-
-    sed = SED()                             # discover default data directories
-    matches = sed.find_model(5777, 4.44, 0) # inspect available grids
-    model = sed.model(matches[0].name)
-    spec = model(5777, 4.44, 0.0)           # interpolate a spectrum
-    gaia = spec.photometry("GAIA")         # synthetic GAIA magnitudes
-
-For range-based discovery a convenience wrapper is also provided::
-
-    from sed_tools import find_atmospheres
-
-    grids = find_atmospheres(teff_range=(5000, 6500), metallicity_range=(-0.5, 0.5))
-
-The package reuses the heavy lifting that already powers the interactive tools
-shipped with SED Tools so that workflows built on the CLI continue to operate
-unchanged while pipelines can opt into the same functionality via imports.
-"""
+"""Public package interface for SED Tools."""
 
 from __future__ import annotations
 
 import os
-import sys
+from importlib import metadata
 from typing import Optional, Sequence, Union
 
-import h5py
-import numpy as np
-
-from .mast_spectra_grabber import MASTSpectraGrabber
-from .models import (DATA_DIR_DEFAULT, FILTER_DIR_DEFAULT, SED as _SEDCore,
-                     STELLAR_DIR_DEFAULT, EvaluatedSED, ModelMatch,
-                     PhotometryResult, SEDModel)
-from .msg_spectra_grabber import \
-    MSGSpectraGrabber  # MSG (Townsend) .h5 → .txt + lookup_table.csv
-from .njm_filter_grabber import NJMFilterGrabber
-from .njm_spectra_grabber import NJMSpectraGrabber  # Niall J Miller
-from .precompute_flux_cube import \
-    precompute_flux_cube  # builds flux cube from lookup + .txt
-from .spectra_cleaner import clean_model_dir
-from .svo_regen_spectra_lookup import regenerate_lookup_table
-from .svo_spectra_grabber import \
-    SVOSpectraGrabber  # SVO spectra → .txt + lookup_table.csv
-
-from .header_parser import parse_header
-
 from .api import (
-    SED,  # This replaces/extends the existing SED from models
     Catalog,
     CatalogInfo,
-    Spectrum,
     Filters,
     MLCompleter,
-    query,
+    SED,
+    Spectrum,
     fetch,
     local,
+    query,
+)
+from .io_utils import (
+    build_h5_bundle_from_txt,
+    ensure_dir,
+    list_txt_spectra,
+    load_txt_spectrum,
+)
+from .models import (
+    DATA_DIR_DEFAULT,
+    FILTER_DIR_DEFAULT,
+    STELLAR_DIR_DEFAULT,
+    EvaluatedSED,
+    ModelMatch,
+    PhotometryResult,
+    SED as _SEDCore,
+    SEDModel,
 )
 
-
-__version__ = "0.1.0"
-
-
-def ensure_dir(path: str) -> None:
-    os.makedirs(path, exist_ok=True)
-
-def list_txt_spectra(model_dir: str) -> List[str]:
-    return sorted([f for f in os.listdir(model_dir) if f.lower().endswith(".txt")])
-
-def load_txt_spectrum(txt_path: str) -> Tuple[np.ndarray, np.ndarray]:
-    wl, fl = [], []
-    with open(txt_path, "r", encoding="utf-8", errors="ignore") as f:
-        for line in f:
-            s = line.strip()
-            if not s or s.startswith("#"):
-                continue
-            parts = s.split()
-            if len(parts) >= 2:
-                try:
-                    wl.append(float(parts[0]))
-                    fl.append(float(parts[1]))
-                except ValueError:
-                    continue
-    return np.asarray(wl, dtype=float), np.asarray(fl, dtype=float)
+try:
+    __version__ = metadata.version("sed-tools")
+except metadata.PackageNotFoundError:
+    __version__ = "0.1.2"
 
 
-def build_h5_bundle_from_txt(model_dir: str, out_h5: str) -> None:
-    """
-    Create an HDF5 file bundling all .txt spectra under groups:
-      /spectra/<filename>/lambda (float64)
-      /spectra/<filename>/flux   (float64)
-    And store key metadata as HDF5 attributes on each group:
-      attrs: teff, logg, feh (if found), plus all raw header pairs in attrs["raw:<key>"]
-    """
-    txt_files = list_txt_spectra(model_dir)
-    if not txt_files:
-        print(f"[H5 bundle] No .txt spectra found in {model_dir}; skipping.")
-        return
+def run_rebuild_flow(*args, **kwargs):
+    """Run the CLI rebuild workflow without importing CLI machinery at startup."""
+    from .cli import run_rebuild_flow as _run_rebuild_flow
 
-    ensure_dir(os.path.dirname(out_h5))
-    with h5py.File(out_h5, "w") as h5:
-        spectra_grp = h5.create_group("spectra")
-        for fname in txt_files:
-            path = os.path.join(model_dir, fname)
-            try:
-                wl, fl = load_txt_spectrum(path)
-                if wl.size == 0 or fl.size == 0:
-                    print(f"[H5 bundle] Empty or invalid spectrum: {fname}")
-                    continue
-                g = spectra_grp.create_group(fname)
-                g.create_dataset("lambda", data=wl, dtype="f8")
-                g.create_dataset("flux",   data=fl, dtype="f8")
-
-                meta = parse_header(path)
-                teff = meta.get("teff", np.nan)
-                logg = meta.get("logg", np.nan)
-                feh  = meta.get("metallicity", np.nan)
-                if not np.isnan(teff): g.attrs["teff"] = teff
-                if not np.isnan(logg): g.attrs["logg"] = logg
-                if not np.isnan(feh):  g.attrs["feh"]  = feh
-                # stash raw header lines so nothing is lost
-                for k, v in meta.items():
-                    g.attrs[f"raw:{k}"] = v
-            except Exception as e:
-                print(f"[H5 bundle] Error on {fname}: {e}")
-
-    print(f"[H5 bundle] Wrote {out_h5}")
-
-def run_rebuild_flow(base_dir: str = STELLAR_DIR_DEFAULT,
-                     models: List[str] = None,
-                     rebuild_h5: bool = True,
-                     rebuild_flux_cube: bool = True) -> None:
-    """
-    Rebuild lookup_table.csv (+ optional HDF5 bundle and flux cube)
-    for existing local model directories. Now cleans spectra first.
-    """
-    import glob
-    ensure_dir(base_dir)
-
-    # discover local model dirs by presence of .txt or .h5
-    cand = []
-    for name in sorted(os.listdir(base_dir)):
-        p = os.path.join(base_dir, name)
-        if not os.path.isdir(p):
-            continue
-        has_txt = any(fn.lower().endswith(".txt") for fn in os.listdir(p))
-        has_h5  = any(fn.lower().endswith(".h5") for fn in os.listdir(p))
-        if has_txt or has_h5:
-            cand.append(name)
-
-    if not cand:
-        print(f"No local models found under {base_dir}")
-        return
-
-    if models is None:
-        print("\nLocal models available for rebuild:")
-        print("-" * 64)
-        for i, m in enumerate(cand, 1):
-            print(f"{i:3d}. {m}")
-        print("\nSelect indices (comma / ranges like 3-6) or 'all':")
-        raw = input("> ").strip().lower()
-        if raw == "all":
-            selected = cand
-        else:
-            idxs = []
-            for token in raw.split(","):
-                token = token.strip()
-                if "-" in token:
-                    a, b = token.split("-", 1)
-                    idxs += list(range(int(a), int(b)+1))
-                else:
-                    if token:
-                        idxs.append(int(token))
-            selected = [cand[i-1] for i in idxs if 1 <= i <= len(cand)]
-    else:
-        selected = models
-
-    if not selected:
-        print("Nothing selected.")
-        return
-
-    # optional SVO lookup regen helper
-    regen = None
-    try:
-        from .svo_regen_spectra_lookup import \
-            regenerate_lookup_table as regen  # type: ignore
-    except Exception:
-        regen = None
-
-    # cleaner
-    try:
-        from .spectra_cleaner import clean_model_dir
-    except Exception as e:
-        clean_model_dir = None
-        print(f"[clean] cleaner unavailable: {e}")
-
-    for model_name in selected:
-        print("\n" + "="*64)
-        print(f"[rebuild] {model_name}")
-        model_dir = os.path.join(base_dir, model_name)
-
-        # 0) CLEAN FIRST (fix λ<=0, repair index grids via HDF5 when possible)
-        if clean_model_dir:
-            try:
-                summary = clean_model_dir(model_dir, try_h5_recovery=True, rebuild_lookup=True)
-                print(f"[clean] {model_name}: total={summary['total']}, "
-                      f"fixed={len(summary['fixed'])}, recovered={len(summary['recovered'])}, "
-                      f"skipped={len(summary['skipped'])}, deleted={len(summary['deleted'])}")
-            except Exception as e:
-                print(f"[clean] failed for {model_name}: {e}")
-
-        # If no .txt remain, skip this model
-        txts = glob.glob(os.path.join(model_dir, "*.txt"))
-        if not txts:
-            print(f"[rebuild] no spectra (.txt) present after cleaning; skipping {model_name}.")
-            continue
-
-        # 1) lookup table
-        try:
-            if regen:
-                regen(model_dir)
-                print("[rebuild] lookup_table.csv via svo_regen_spectra_lookup")
-            else:
-                regenerate_lookup_table(model_dir)
-        except Exception as e:
-            print(f"[rebuild] lookup failed: {e}")
-
-        # 2) HDF5 bundle (from .txt), ensure it exists
-        if rebuild_h5:
-            out_h5 = os.path.join(model_dir, f"{model_name}.h5")
-            try:
-                build_h5_bundle_from_txt(model_dir, out_h5)
-            except Exception as e:
-                print(f"[rebuild] h5 bundle failed: {e}")
-
-        # 3) flux cube
-        if rebuild_flux_cube:
-            out_flux = os.path.join(model_dir, "flux_cube.bin")
-            try:
-                precompute_flux_cube(model_dir, out_flux)
-            except Exception as e:
-                print(f"[rebuild] flux cube failed: {e}")
-
-    print("\nRebuild complete.")
-
-import glob
-import os
-from typing import List, Tuple
-
-# assumes in scope:
-# ensure_dir, STELLAR_DIR_DEFAULT
-# SVOSpectraGrabber, MSGSpectraGrabber, MASTSpectraGrabber
-# build_h5_bundle_from_txt, regenerate_lookup_table, precompute_flux_cube
-# and: from SED_tools.cli import _prompt_choice
-
-def _srcs(s: str) -> List[str]:
-    s = s.lower()
-    return {"svo":["svo"], "msg":["msg"], "mast":["mast"], "both":["svo","msg"], "all":["svo","msg","mast"]}[s]
-
-class _Opt:
-    __slots__ = ("src","name","label")
-    def __init__(self, src, name):
-        self.src, self.name = src, name
-        self.label = f"{name} [{src}]"
-
-def run_spectra_flow(
-    source: str,
-    base_dir: str = STELLAR_DIR_DEFAULT,
-    models: List[str] = None,
-    workers: int = 5,
-    force_bundle_h5: bool = True,
-    build_flux_cube: bool = True
-) -> None:
-    from .spectra_cleaner import clean_model_dir
-
-    ensure_dir(base_dir)
-    src_list = _srcs(source)
-
-    grabs = {}
-    if "svo" in src_list:  grabs["svo"]  = SVOSpectraGrabber(base_dir=base_dir, max_workers=workers)
-    if "msg" in src_list:  grabs["msg"]  = MSGSpectraGrabber(base_dir=base_dir, max_workers=workers)
-    if "mast" in src_list: grabs["mast"] = MASTSpectraGrabber(base_dir=base_dir, max_workers=workers)
-
-    discovered: List[Tuple[str,str]] = [(s, m) for s in src_list for m in grabs[s].discover_models()]
-    if models is None and not discovered:
-        print("No models discovered."); return
-
-    if models is not None:
-        if len(models)==1 and models[0].lower()=="all":
-            chosen = discovered
-        else:
-            chosen = []
-            for m in models:
-                if ":" in m:
-                    src, name = m.split(":",1); src, name = src.strip().lower(), name.strip()
-                else:
-                    if len(src_list)!=1: raise ValueError(f"Ambiguous '{m}' with source='{source}'. Use 'src:model'.")
-                    src, name = src_list[0], m.strip()
-                if (src,name) not in discovered: raise ValueError(f"Model '{name}' not found in '{src}'.")
-                chosen.append((src,name))
-    else:
-        opts = [_Opt(s,n) for s,n in discovered]
-        idx = _prompt_choice(opts, label="Spectral models", allow_back=True)
-        if idx is None or idx==-1: print("No model selected."); return
-        sel = opts[idx]; chosen = [(sel.src, sel.name)]
-
-    for src, name in chosen:
-        print("\n"+"="*64); print(f"[{src}] {name}")
-        model_dir = os.path.join(base_dir, name); ensure_dir(model_dir)
-
-        g = grabs[src]
-        meta = g.get_model_metadata(name)
-        if not meta: print(f"[{src}] No metadata for {name}; skip."); continue
-        n_written = g.download_model_spectra(name, meta)
-        print(f"[{src}] wrote {n_written} spectra -> {model_dir}")
-
-        summary = clean_model_dir(model_dir, try_h5_recovery=True, rebuild_lookup=True)
-        print(f"[clean] total={summary['total']} fixed={len(summary['fixed'])} "
-              f"recovered={len(summary['recovered'])} skipped={len(summary['skipped'])} "
-              f"deleted={len(summary['deleted'])}")
-
-        if not glob.glob(os.path.join(model_dir, "*.txt")):
-            print(f"[{src}] no .txt after cleaning; skip downstream."); continue
-
-        if src == "msg":
-            out_h5 = os.path.join(model_dir, f"{name}_bundle.h5")
-            if force_bundle_h5 and not os.path.exists(out_h5):
-                build_h5_bundle_from_txt(model_dir, out_h5)
-        else:
-            out_h5 = os.path.join(model_dir, f"{name}.h5")
-            if force_bundle_h5 or not os.path.exists(out_h5):
-                build_h5_bundle_from_txt(model_dir, out_h5)
-
-        print("[lookup] rebuilding lookup_table.csv"); regenerate_lookup_table(model_dir)
-
-        if build_flux_cube:
-            precompute_flux_cube(model_dir, os.path.join(model_dir,"flux_cube.bin"))
-
-    print("\nDone.")
+    return _run_rebuild_flow(*args, **kwargs)
 
 
-#!/usr/bin/env python3
-"""
-ADD THIS FUNCTION TO sed_tools/__init__.py or sed_tools/cli.py
+def run_spectra_flow(*args, **kwargs):
+    """Run the CLI spectra download workflow."""
+    from .cli import run_spectra_flow as _run_spectra_flow
 
-Place it after run_rebuild_flow() function.
-"""
-
-def run_combine_flow(
-    base_dir: str = STELLAR_DIR_DEFAULT,
-    output_name: str = "combined_models", 
-    interactive: bool = True
-) -> None:
-    """
-    Combine multiple stellar atmosphere grids into unified omni grid.
-    
-    This creates a single flux cube spanning the parameter space of all
-    selected models, normalized to a reference (preferably Kurucz).
-    
-    Args:
-        base_dir: Base directory containing stellar_models/ subdirectories
-        output_name: Name for the output combined model directory  
-        interactive: If True, prompt user to select models
-    """
-    from .combine_stellar_atm import (build_combined_flux_cube,
-                                      create_common_wavelength_grid,
-                                      create_unified_grid, find_stellar_models,
-                                      load_model_data, save_combined_data,
-                                      select_models_interactive,
-                                      visualize_parameter_space)
-    
-    ensure_dir(base_dir)
-    
-    # Find available models
-    model_dirs = find_stellar_models(base_dir)
-    
-    if not model_dirs:
-        print(f"No stellar models found in {base_dir}")
-        print("Download some models first using option 1 (Spectra)")
-        return
-    
-    print(f"\nFound {len(model_dirs)} stellar atmosphere models")
-    
-    # Select models to combine
-    if interactive:
-        selected = select_models_interactive(model_dirs)
-    else:
-        selected = model_dirs
-    
-    if not selected:
-        print("No models selected.")
-        return
-    
-    if len(selected) < 2:
-        print("Warning: Need at least 2 models for meaningful combination.")
-        if interactive:
-            confirm = input("Continue with 1 model? [y/N] ").strip().lower()
-            if not confirm.startswith('y'):
-                return
-    
-    print(f"\nSelected {len(selected)} models to combine:")
-    for name, _ in selected:
-        print(f"  - {name}")
-    
-    # Get output name
-    if interactive:
-        user_output = input(f"\nOutput directory name [{output_name}]: ").strip()
-        if user_output:
-            output_name = user_output
-    
-    # Load model data
-    print("\nLoading model data...")
-    all_models = []
-    for name, path in selected:
-        print(f"  Loading {name}...")
-        all_models.append(load_model_data(path))
-    
-    # Create unified grids
-    print("\nCreating unified parameter grids...")
-    teff_grid, logg_grid, meta_grid = create_unified_grid(all_models)
-    wavelength_grid = create_common_wavelength_grid(all_models)
-    
-    # Show grid info
-    total_points = len(teff_grid) * len(logg_grid) * len(meta_grid)
-    print(f"\nUnified grid dimensions:")
-    print(f"  Teff:  {len(teff_grid)} points  " +
-          f"({teff_grid.min():.0f} - {teff_grid.max():.0f} K)")
-    print(f"  log g: {len(logg_grid)} points  " +
-          f"({logg_grid.min():.2f} - {logg_grid.max():.2f})")
-    print(f"  [M/H]: {len(meta_grid)} points  " +
-          f"({meta_grid.min():.2f} - {meta_grid.max():.2f})")
-    print(f"  λ:     {len(wavelength_grid)} points " +
-          f"({wavelength_grid.min():.0f} - {wavelength_grid.max():.0f} Å)")
-    print(f"\nTotal grid points: {total_points:,}")
-    
-    # Confirm before proceeding
-    if interactive:
-        confirm = input("\nProceed with building combined flux cube? [Y/n] ").strip().lower()
-        if confirm and not confirm.startswith('y'):
-            print("Cancelled.")
-            return
-    
-    # Build combined flux cube
-    print("\nBuilding combined flux cube...")
-    print("(This may take several minutes for large grids)")
-    flux_cube, source_map = build_combined_flux_cube(
-        all_models, teff_grid, logg_grid, meta_grid, wavelength_grid
-    )
-    
-    # Save combined data
-    output_dir = os.path.join(base_dir, output_name)
-    print(f"\nSaving combined model to: {output_dir}")
-    save_combined_data(
-        output_dir,
-        teff_grid,
-        logg_grid, 
-        meta_grid,
-        wavelength_grid,
-        flux_cube,
-        all_models
-    )
-    
-    # Create visualizations
-    print("\nCreating parameter space visualizations...")
-    visualize_parameter_space(
-        teff_grid, logg_grid, meta_grid, source_map, all_models, output_dir
-    )
-    
-    # Success message
-    print("\n" + "="*70)
-    print("SUCCESS: Omni grid created!")
-    print("="*70)
-    print(f"\nYour combined model is ready at:")
-    print(f"  {output_dir}")
-    print(f"\nContents:")
-    print(f"  • flux_cube.bin - MESA-ready flux cube")
-    print(f"  • lookup_table.csv - Combined model inventory")
-    print(f"  • parameter_space_visualization.png - Coverage maps")
-    print(f"  • Original spectra from all source models")
-    print(f"\nTo use in MESA, set in your inlist:")
-    print(f"  stellar_atm = '/colors/data/stellar_models/{output_name}/'")
-    print()
+    return _run_spectra_flow(*args, **kwargs)
 
 
+def run_filters_flow(*args, **kwargs):
+    """Run the CLI filter download workflow."""
+    from .cli import run_filters_flow as _run_filters_flow
+
+    return _run_filters_flow(*args, **kwargs)
 
 
+def run_combine_flow(*args, **kwargs):
+    """Run the CLI grid-combination workflow."""
+    from .cli import run_combine_flow as _run_combine_flow
 
-def menu() -> str:
-    print("\nWhat would you like to run?")
-    print("  1) Spectra (NJM / SVO / MSG / MAST)")
-    print("  2) Filters (NJM / SVO)")
-    print("  3) Rebuild (lookup + HDF5 + flux cube)")
-    print("  4) Combine grids into omni grid")  # ← ADD THIS LINE
-    print("  0) Quit")
-    choice = input("> ").strip()
-    mapping = {
-        "1": "spectra", 
-        "2": "filters", 
-        "3": "rebuild",
-        "4": "combine",  # ← ADD THIS LINE
-        "0": "quit"
-    }
-    return mapping.get(choice, "")
+    return _run_combine_flow(*args, **kwargs)
 
 
-def run_filters_flow(base_dir: str = FILTER_DIR_DEFAULT) -> None:
-    """Interactive nested filter downloader that mirrors the spectra workflow."""
-    ensure_dir(base_dir)
-    try:
-        from .svo_filter_grabber import run_interactive as _run_filter_cli
-    except Exception as exc:
-        print("This feature needs requests/bs4/astroquery available:", exc)
-        return
+def menu(*args, **kwargs):
+    """Display the CLI menu."""
+    from .cli import menu as _menu
 
-    _run_filter_cli(base_dir)
-
+    return _menu(*args, **kwargs)
 
 
 def find_atmospheres(
@@ -534,7 +86,6 @@ def find_atmospheres(
     filter_root: Optional[Union[str, os.PathLike[str]]] = None,
 ) -> list[ModelMatch]:
     """Discover locally available model grids matching the requested ranges."""
-
     sed = _SEDCore(model_root=model_root, filter_root=filter_root)
     return sed.find_atmospheres(
         teff_range=teff_range,
@@ -546,8 +97,7 @@ def find_atmospheres(
 
 
 def find_atm(**kwargs) -> list[ModelMatch]:
-    """Alias for :func:`find_atmospheres` matching the historical API sketch."""
-
+    """Backward-compatible alias for :func:`find_atmospheres`."""
     for legacy_key in ("Z_range", "z_range"):
         if legacy_key in kwargs and "metallicity_range" not in kwargs:
             kwargs["metallicity_range"] = kwargs.pop(legacy_key)
@@ -557,201 +107,32 @@ def find_atm(**kwargs) -> list[ModelMatch]:
 
 
 __all__ = [
-    # Core API
     "SED",
-    "Catalog", 
+    "Catalog",
     "CatalogInfo",
     "Spectrum",
     "Filters",
     "MLCompleter",
-    
-    # Convenience functions
     "query",
-    "fetch", 
+    "fetch",
     "local",
-    
-    # Existing exports (keep these)
     "SEDModel",
     "EvaluatedSED",
     "PhotometryResult",
     "ModelMatch",
-    "run_combine_flow",
     "DATA_DIR_DEFAULT",
     "STELLAR_DIR_DEFAULT",
     "FILTER_DIR_DEFAULT",
+    "ensure_dir",
+    "list_txt_spectra",
+    "load_txt_spectrum",
+    "build_h5_bundle_from_txt",
+    "run_rebuild_flow",
+    "run_spectra_flow",
+    "run_filters_flow",
+    "run_combine_flow",
+    "menu",
     "find_atmospheres",
     "find_atm",
     "__version__",
 ]
-
-
-
-
-
-
-
-
-import math
-import os
-import re
-import shutil
-import sys
-from typing import Any, List, Optional, Sequence, Tuple
-
-
-def _prompt_choice(
-    options: Sequence,
-    label: str,
-    allow_back: bool = False,
-    page_size: int = 100,
-    max_label: int = -1,
-    min_cols: int = 1,
-    max_cols: int = 3,
-    use_color: bool = True,
-) -> Optional[int]:
-    """
-    Plain-ASCII picker with stable IDs, paging, grid columns, and simple filters.
-    - Stable IDs: 1..N (do not renumber after filtering/paging)
-    - Pagination: n / p / g <page>
-    - Filters: /text (substring), !text (negated), //regex (case-insensitive)
-    - Select by ID: 'id <N>' or just '<N>'
-    Returns 0-based index, -1 for back (if allowed), None for quit.
-    """
-    if not options:
-        print(f"No {label} options available.")
-        return None
-
-
-    if max_label < 0:
-        max_label = max(len(getattr(x, "label", str(x))) for x in options) + 4
-
-
-    # ---- setup ----
-    labels: List[str] = [getattr(o, "label", str(o)) for o in options]
-    N = len(labels)
-    page = 1
-    filt: Optional[Tuple[str, str]] = None  # ('substr'|'neg'|'regex', pattern)
-
-    # color toggles
-    use_color = use_color and sys.stdout.isatty() and ("NO_COLOR" not in os.environ)
-    BOLD = "\x1b[1m" if use_color else ""
-    DIM = "\x1b[2m" if use_color else ""
-    CYAN = "\x1b[36m" if use_color else ""
-    YELL = "\x1b[33m" if use_color else ""
-    RED = "\x1b[31m" if use_color else ""
-    GREEN = "\x1b[32m" if use_color else ""
-    YELLOW = "\x1b[33m" if use_color else ""
-    BLUE = "\x1b[34m" if use_color else ""
-    MAGENTA = "\x1b[35m" if use_color else ""
-    WHITE = "\x1b[37m" if use_color else ""
-    RESET = "\x1b[0m" if use_color else ""
-
-    def term_width() -> int:
-        try: return shutil.get_terminal_size().columns
-        except: return 80
-
-    def apply_filter(idx: List[int]) -> List[int]:
-        if filt is None: return idx
-        kind, patt = filt
-        if kind == "substr":
-            p = patt.lower()
-            return [i for i in idx if p in labels[i].lower()]
-        if kind == "neg":
-            p = patt.lower()
-            return [i for i in idx if p not in labels[i].lower()]
-        # regex
-        rx = re.compile(patt, re.I)
-        return [i for i in idx if rx.search(labels[i])]
-
-    def page_slice(total: int, p: int) -> slice:
-        pmax = max(1, math.ceil(total / page_size))
-        if p > pmax: p = pmax
-        if p < 1: p = 1
-        a = (p - 1) * page_size
-        b = min(a + page_size, total)
-        return slice(a, b)
-
-    def ellipsize(s: str) -> str:
-        return s if len(s) <= max_label else s[:max_label - 1] + "…"
-
-    def hl(s: str) -> str:
-        if not use_color or filt is None: return s
-        kind, patt = filt
-        if kind != "substr" or not patt: return s
-        rx = re.compile(re.escape(patt), re.I)
-        return rx.sub(lambda m: f"{YELL}{m.group(0)}{RESET}", s)
-
-    def grid_print(visible_ids: List[int]) -> None:
-        width = max(80, term_width())
-        names = [labels[i] for i in visible_ids]
-        col_w = 6 + max_label + 2     # "[####] " + label + gap
-        cols = max(min_cols, min(max_cols, max(1, width // col_w)))
-        cells = [f"[{GREEN}{i+1:4d}{RESET}] {hl(ellipsize(s))}" for i, s in zip(visible_ids, names)]
-        while len(cells) % cols: cells.append("")
-        rows = [cells[k:k+cols] for k in range(0, len(cells), cols)]
-        print(f"\n{BOLD}{label}{RESET} ({CYAN}{len(all_idx)}{RESET} total):")
-        print("─" * min(80, width))
-        for r in rows:
-            print("  ".join(x.ljust(col_w - 2) for x in r))
-
-    # ---- loop ----
-    all_idx = list(range(N))
-    while True:
-        kept = apply_filter(all_idx)
-        sl = page_slice(len(kept), page)
-        view = kept[sl]
-        start, end = sl.start + 1, sl.stop
-        grid_print(view)
-
-        ftxt = ""
-        if filt:
-            kind, patt = filt
-            ftxt = f' {DIM}filter="/{patt}"{RESET}' if kind == "substr" else (
-                   f' {DIM}filter="!{patt}"{RESET}' if kind == "neg" else
-                   f' {DIM}filter="//{patt}"{RESET}')
-        if end < len(kept):
-            print(f"{DIM}Showing {start}–{end} of {len(kept)}{ftxt}{RESET}")
-            controls = f"{DIM}n, p, g <page>, /text, !text, //regex, id <N> (or just N), clear"
-            if allow_back: controls += ", b"
-        else:
-            controls = f"{DIM}/text, !text, //regex, id <N> (or just N), clear"
-        controls += ", q" + RESET
-        print(controls)
-
-        inp = input("> ").strip()
-        if not inp: continue
-        low = inp.lower()
-
-        if low in ("q", "quit", "exit"): return None
-        if allow_back and low in ("b", "back"): return -1
-        if low == "n": page += 1; continue
-        if low == "p": page -= 1; continue
-        if low.startswith("g "):
-            parts = low.split()
-            if len(parts) == 2 and parts[1].isdigit(): page = int(parts[1])
-            continue
-        if low == "clear": filt = None; page = 1; continue
-        if low.startswith("//"): patt = inp[2:].strip(); filt = ("regex", patt) if patt else None; page = 1; continue
-        if low.startswith("!"):  patt = inp[1:].strip();  filt = ("neg", patt)   if patt else None; page = 1; continue
-        if low.startswith("/"):  patt = inp[1:].strip();  filt = ("substr", patt)if patt else None; page = 1; continue
-        if low.startswith("id "):
-            parts = low.split()
-            if len(parts) == 2 and parts[1].isdigit():
-                k = int(parts[1])
-                if 1 <= k <= N: return k - 1
-            continue
-        if inp.isdigit():
-            k = int(inp)
-            if 1 <= k <= N: return k - 1
-            continue
-
-        # default: substring filter
-        filt = ("substr", inp); page = 1
-
-
-
-
-
-
-
-

--- a/sed_tools/api.py
+++ b/sed_tools/api.py
@@ -39,19 +39,15 @@ Example usage::
 
 from __future__ import annotations
 
-import csv
-import os
-import shutil
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Callable, Dict, Iterator, List, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd
 
 # Import existing infrastructure
 from .models import (
-    DATA_DIR_DEFAULT,
     FILTER_DIR_DEFAULT,
     STELLAR_DIR_DEFAULT,
     EvaluatedSED,
@@ -324,7 +320,7 @@ class Catalog:
         
         # Build H5 bundle
         if build_h5 and len(self.spectra) > 0:
-            from . import build_h5_bundle_from_txt
+            from .io_utils import build_h5_bundle_from_txt
             try:
                 build_h5_bundle_from_txt(str(path), str(path / f"{self.name}.h5"))
                 print(f"[write] Built {self.name}.h5")

--- a/sed_tools/api.py
+++ b/sed_tools/api.py
@@ -1452,55 +1452,129 @@ class Filters:
     
     @classmethod
     def _query_local(cls, facility: Optional[str] = None) -> List[Dict[str, Any]]:
-        """Query locally installed filters."""
+        """Query locally installed filters.
+
+        Empty/incomplete filter directories are ignored. This avoids treating a
+        failed partial download, e.g. a directory containing only an index file,
+        as a valid local filter set.
+        """
         results = []
-        
+
         if not cls._filter_root.exists():
             return results
-        
+
         for fac_dir in sorted(cls._filter_root.iterdir()):
             if not fac_dir.is_dir():
                 continue
             if facility and fac_dir.name.lower() != facility.lower():
                 continue
-            
+
             for inst_dir in sorted(fac_dir.iterdir()):
                 if not inst_dir.is_dir():
                     continue
-                
-                filters = list(inst_dir.glob("*.dat"))
+
+                filters = sorted(inst_dir.glob("*.dat"))
+                if not filters:
+                    continue
+
                 results.append({
                     'facility': fac_dir.name,
                     'instrument': inst_dir.name,
                     'n_filters': len(filters),
                     'is_local': True,
                 })
-        
+
         return results
-    
+
     @classmethod
     def _query_remote(cls, facility: Optional[str] = None) -> List[Dict[str, Any]]:
-        """Query remote filter sources (SVO, NJM)."""
-        results = []
-        
+        """Query remote filter sources.
+
+        SVO is treated as the authoritative discovery catalogue. The NJM mirror
+        is also reported when available, but fetch() still validates actual .dat
+        files before accepting a download.
+        """
+        results: List[Dict[str, Any]] = []
+
+        # SVO catalogue
         try:
             from .svo_filter_grabber import SVOFilterBrowser
             browser = SVOFilterBrowser(base_dir=str(cls._filter_root))
             facilities = browser.list_facilities()
-            
+
             for fac in facilities:
-                if facility and fac.label.lower() != facility.lower():
+                names = {fac.label.lower(), fac.key.lower()}
+                if facility and facility.lower() not in names:
                     continue
                 results.append({
                     'facility': fac.label,
+                    'facility_key': fac.key,
                     'source': 'svo',
                     'is_local': False,
                 })
         except Exception:
             pass
-        
+
+        # NJM mirror catalogue, if available. Avoid exact duplicate rows.
+        try:
+            from .njm_filter_grabber import NJMFilterGrabber
+            njm = NJMFilterGrabber(base_dir=str(cls._filter_root))
+            if njm.is_available():
+                seen = {
+                    (r.get('facility', '').lower(), r.get('source', '').lower())
+                    for r in results
+                }
+                for fac in njm.discover_facilities():
+                    if facility and fac.lower() != facility.lower():
+                        continue
+                    key = (fac.lower(), 'njm')
+                    if key in seen:
+                        continue
+                    results.append({
+                        'facility': fac,
+                        'source': 'njm',
+                        'is_local': False,
+                    })
+                    seen.add(key)
+        except Exception:
+            pass
+
         return results
-    
+
+    @staticmethod
+    def _find_filter_dir(base_dir: Path, *candidates: Path) -> Optional[Path]:
+        """Return the first candidate directory containing .dat filter files."""
+        for candidate in candidates:
+            if candidate.exists() and candidate.is_dir():
+                if list(candidate.glob("*.dat")):
+                    return candidate
+        return None
+
+    @staticmethod
+    def _remove_empty_filter_dir(path: Path) -> None:
+        """Remove a partial filter directory only when it has no .dat files."""
+        if not path.exists() or not path.is_dir():
+            return
+        if list(path.glob("*.dat")):
+            return
+
+        # Failed NJM downloads can leave only an instrument index file. Remove
+        # files in the leaf directory, then prune empty parents cautiously.
+        for child in path.iterdir():
+            if child.is_file() and child.name == path.name:
+                try:
+                    child.unlink()
+                except OSError:
+                    pass
+
+        try:
+            path.rmdir()
+            parent = path.parent
+            if parent.exists() and parent.is_dir() and not any(parent.iterdir()):
+                parent.rmdir()
+        except OSError:
+            pass
+
     @classmethod
     def fetch(
         cls,
@@ -1510,68 +1584,96 @@ class Filters:
     ) -> Path:
         """
         Download filter profiles.
-        
-        Parameters
-        ----------
-        facility : str
-            Facility name (e.g., 'Generic', 'HST')
-        instrument : str
-            Instrument name (e.g., 'Johnson', 'WFC3')
-        filter_root : str or Path, optional
-            Base directory for filters
-            
-        Returns
-        -------
-        Path
-            Directory where filters were saved
+
+        Tries an existing local installation first, then the NJM mirror, then
+        SVO. A source is considered successful only if real ``*.dat`` files are
+        present in the final directory.
         """
         base_dir = Path(filter_root) if filter_root else cls._filter_root
+        base_dir.mkdir(parents=True, exist_ok=True)
         output_path = base_dir / facility / instrument
-        
-        # Check if already exists locally
-        if output_path.exists():
-            existing = list(output_path.glob("*.dat"))
-            if existing:
-                print(f"[filters] Already have {len(existing)} filters at {output_path}")
-                return output_path
-        
-        # Try NJM first
+
+        # Check if already exists locally and is complete enough to use.
+        existing_dir = cls._find_filter_dir(base_dir, output_path)
+        if existing_dir:
+            existing = list(existing_dir.glob("*.dat"))
+            print(f"[filters] Already have {len(existing)} filters at {existing_dir}")
+            return existing_dir
+
+        # Try NJM first.
         try:
             from .njm_filter_grabber import NJMFilterGrabber
             njm = NJMFilterGrabber(base_dir=str(base_dir))
             if njm.is_available():
-                njm.download_filters(facility, instrument)
-                # Check if files now exist
-                if output_path.exists():
-                    existing = list(output_path.glob("*.dat"))
-                    if existing:
-                        print(f"[filters] Got {len(existing)} filters from NJM")
-                        return output_path
+                count = njm.download_filters(facility, instrument)
+                existing_dir = cls._find_filter_dir(base_dir, output_path)
+                if existing_dir:
+                    existing = list(existing_dir.glob("*.dat"))
+                    print(f"[filters] Got {len(existing)} filters from NJM")
+                    return existing_dir
+                if count == 0:
+                    cls._remove_empty_filter_dir(output_path)
         except Exception as e:
             print(f"[filters] NJM failed: {e}")
-        
-        # Fall back to SVO
+
+        # Fall back to SVO. SVO uses facility/instrument *keys* for browsing,
+        # but writes output directories from the returned filter-row labels, so
+        # we check both the requested names and the actual row names.
         try:
-            from .svo_filter_grabber import SVOFilterBrowser
+            from .svo_filter_grabber import SVOFilterBrowser, _clean_path
             browser = SVOFilterBrowser(base_dir=str(base_dir))
-            
-            # Navigate and download
+
             facilities = browser.list_facilities()
-            fac = next((f for f in facilities if f.label.lower() == facility.lower()), None)
-            if fac:
-                instruments = browser.list_instruments(fac)
-                inst = next((i for i in instruments if i.label.lower() == instrument.lower()), None)
-                if inst:
-                    filters = browser.list_filters(inst)
-                    browser.download_filters(filters)
-                    if output_path.exists():
-                        existing = list(output_path.glob("*.dat"))
-                        if existing:
-                            print(f"[filters] Got {len(existing)} filters from SVO")
-                            return output_path
+            fac = next(
+                (
+                    f for f in facilities
+                    if f.label.lower() == facility.lower()
+                    or f.key.lower() == facility.lower()
+                ),
+                None,
+            )
+            if fac is None:
+                raise ValueError(f"SVO facility not found: {facility}")
+
+            instruments = browser.list_instruments(fac.key)
+            inst = next(
+                (
+                    i for i in instruments
+                    if i.label.lower() == instrument.lower()
+                    or i.key.lower() == instrument.lower()
+                ),
+                None,
+            )
+            if inst is None:
+                raise ValueError(f"SVO instrument not found: {facility}/{instrument}")
+
+            filters = browser.list_filters(fac.key, inst.key)
+            if not filters:
+                raise ValueError(f"SVO returned no filters for {facility}/{instrument}")
+
+            browser.download_filters(filters)
+
+            candidates = [
+                output_path,
+                base_dir / fac.label / inst.label,
+                base_dir / fac.key / inst.key,
+            ]
+
+            # SVO rows may contain their own display labels.
+            first = filters[0]
+            candidates.append(
+                base_dir / _clean_path(first.facility) / _clean_path(first.instrument)
+            )
+
+            existing_dir = cls._find_filter_dir(base_dir, *candidates)
+            if existing_dir:
+                existing = list(existing_dir.glob("*.dat"))
+                print(f"[filters] Got {len(existing)} filters from SVO")
+                return existing_dir
+
         except Exception as e:
             print(f"[filters] SVO failed: {e}")
-        
+
         raise ValueError(f"Could not download filters for {facility}/{instrument}")
 
 

--- a/sed_tools/cli.py
+++ b/sed_tools/cli.py
@@ -16,16 +16,10 @@ Filters (SVO only):
 
 import argparse
 import glob
-import math
 import os
-import re
-import shutil
 import sys
-import textwrap
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+from typing import Dict, List, Optional, Tuple
 
-import h5py
-import numpy as np
 
 from .mast_spectra_grabber import MASTSpectraGrabber
 # --- Standard Package Imports (The "Safe" Way) ---
@@ -34,69 +28,12 @@ from .msg_spectra_grabber import MSGSpectraGrabber
 from .njm_spectra_grabber import NJMSpectraGrabber
 from .precompute_flux_cube import precompute_flux_cube
 from .spectra_cleaner import clean_model_dir
-from .svo_filter_grabber import run_interactive as _run_filter_cli
 from .svo_regen_spectra_lookup import regenerate_lookup_table
 from .svo_spectra_grabber import SVOSpectraGrabber
-from .ui_utils import _prompt_choice
-from .header_parser import parse_header
-# ------------ Small Utils ------------
+from .ui_utils import _prompt_choice, parse_multi_selection
+from .io_utils import build_h5_bundle_from_txt, ensure_dir
 
-def ensure_dir(path: str) -> None:
-    os.makedirs(path, exist_ok=True)
-
-
-def list_txt_spectra(model_dir: str) -> List[str]:
-    return sorted([f for f in os.listdir(model_dir) if f.lower().endswith(".txt")])
-
-
-def load_txt_spectrum(txt_path: str) -> Tuple[np.ndarray, np.ndarray]:
-    wl, fl = [], []
-    with open(txt_path, "r", encoding="utf-8", errors="ignore") as f:
-        for line in f:
-            s = line.strip()
-            if not s or s.startswith("#"):
-                continue
-            parts = s.split()
-            if len(parts) >= 2:
-                wl.append(float(parts[0]))
-                fl.append(float(parts[1]))
-    return np.asarray(wl, dtype=float), np.asarray(fl, dtype=float)
-
-
-# ------------ HDF5 Bundling ------------
-
-def build_h5_bundle_from_txt(model_dir: str, out_h5: str) -> None:
-    """Create an HDF5 file bundling all .txt spectra."""
-    txt_files = list_txt_spectra(model_dir)
-    if not txt_files:
-        print(f"[H5 bundle] No .txt spectra found in {model_dir}; skipping.")
-        return
-
-    ensure_dir(os.path.dirname(out_h5))
-    with h5py.File(out_h5, "w") as h5:
-        spectra_grp = h5.create_group("spectra")
-        for fname in txt_files:
-            path = os.path.join(model_dir, fname)
-            wl, fl = load_txt_spectrum(path)
-            g = spectra_grp.create_group(fname)
-            g.create_dataset("lambda", data=wl, dtype="f8")
-            g.create_dataset("flux",   data=fl, dtype="f8")
-
-            meta = parse_header(path)
-            teff = meta.get("teff", np.nan)
-            logg = meta.get("logg", np.nan)
-            feh  = meta.get("metallicity", np.nan)
-
-            if not np.isnan(teff): g.attrs["teff"] = teff
-            if not np.isnan(logg): g.attrs["logg"] = logg
-            if not np.isnan(feh):  g.attrs["feh"] = feh
-            for k, v in meta.items():
-                g.attrs[f"raw:{k}"] = v
-
-    print(f"[H5 bundle] Wrote {out_h5}")
-
-
-# ------------ UI Helpers (Your Full Interactive Menu) ------------
+# ------------ UI Helpers ------------
 
 class _Opt:
     __slots__ = ("src", "name", "label")
@@ -104,180 +41,6 @@ class _Opt:
     def __init__(self, src, name):
         self.src, self.name = src, name
         self.label = f"{name} [{src}]"
-
-
-def _prompt_choice(
-    options: Sequence,
-    label: str,
-    allow_back: bool = False,
-    page_size: int = 100,
-    max_label: int = -1,
-    min_cols: int = 1,
-    max_cols: int = 3,
-    use_color: bool = True,
-    multi: bool = False,
-) -> Union[int, List[int], None]:
-    """
-    Plain-ASCII picker with stable IDs, paging, grid columns, and simple filters.
-    If multi=True, allows input like "1, 3-5" and returns a List[int] of indices.
-    Otherwise returns a single int.
-    Returns None for quit, -1 for back (if allowed).
-    """
-    if not options:
-        print(f"No {label} options available.")
-        return None
-
-    if max_label < 0:
-        max_label = max(len(getattr(x, "label", str(x))) for x in options) + 4
-
-    labels: List[str] = [getattr(o, "label", str(o)) for o in options]
-    N = len(labels)
-    page = 1
-    filt: Optional[Tuple[str, str]] = None
-
-    use_color = use_color and sys.stdout.isatty() and ("NO_COLOR" not in os.environ)
-    BOLD = "\x1b[1m" if use_color else ""
-    DIM = "\x1b[2m" if use_color else ""
-    CYAN = "\x1b[36m" if use_color else ""
-    YELL = "\x1b[33m" if use_color else ""
-    GREEN = "\x1b[32m" if use_color else ""
-    RESET = "\x1b[0m" if use_color else ""
-
-    def term_width() -> int:
-        return shutil.get_terminal_size().columns
-
-    def apply_filter(idx: List[int]) -> List[int]:
-        if filt is None: return idx
-        kind, patt = filt
-        if kind == "substr":
-            p = patt.lower()
-            return [i for i in idx if p in labels[i].lower()]
-        if kind == "neg":
-            p = patt.lower()
-            return [i for i in idx if p not in labels[i].lower()]
-        rx = re.compile(patt, re.I)
-        return [i for i in idx if rx.search(labels[i])]
-
-    def page_slice(total: int, p: int) -> slice:
-        pmax = max(1, math.ceil(total / page_size))
-        if p > pmax: p = pmax
-        if p < 1: p = 1
-        a = (p - 1) * page_size
-        b = min(a + page_size, total)
-        return slice(a, b)
-
-    def ellipsize(s: str) -> str:
-        return s if len(s) <= max_label else s[:max_label - 1] + "…"
-
-    def hl(s: str) -> str:
-        if not use_color or filt is None: return s
-        kind, patt = filt
-        if kind != "substr" or not patt: return s
-        rx = re.compile(re.escape(patt), re.I)
-        return rx.sub(lambda m: f"{YELL}{m.group(0)}{RESET}", s)
-
-    def grid_print(visible_ids: List[int]) -> None:
-        width = max(80, term_width())
-        names = [labels[i] for i in visible_ids]
-        col_w = 12 + max_label + 2
-        cols = max(min_cols, min(max_cols, max(1, width // col_w)))
-        cells = [f"[{GREEN}{i+1:4d}{RESET}] {hl(ellipsize(s))}" for i, s in zip(visible_ids, names)]
-        while len(cells) % cols: cells.append("")
-        rows = [cells[k:k+cols] for k in range(0, len(cells), cols)]
-        print(f"\n{BOLD}{label}{RESET} ({CYAN}{len(all_idx)}{RESET} total):")
-        print("─" * min(80, width))
-        for r in rows:
-            print("".join(x.ljust(col_w - 2) for x in r))
-
-    all_idx = list(range(N))
-    while True:
-        kept = apply_filter(all_idx)
-        sl = page_slice(len(kept), page)
-        view = kept[sl]
-        start, end = sl.start + 1, sl.stop
-        grid_print(view)
-
-        ftxt = ""
-        if filt:
-            kind, patt = filt
-            ftxt = f' {DIM}filter="/{patt}"{RESET}' if kind == "substr" else (
-                   f' {DIM}filter="!{patt}"{RESET}' if kind == "neg" else
-                   f' {DIM}filter="//{patt}"{RESET}')
-        
-        controls = f"{DIM}"
-        if end < len(kept):
-            print(f"{DIM}Showing {start}–{end} of {len(kept)}{ftxt}{RESET}")
-            controls += "n, p, g <page>, "
-        
-        controls += "/text, !text, //regex, "
-        if multi:
-            controls += "list (1,3) or range (1-5), "
-        else:
-            controls += "id <N> (or just N), "
-
-        controls += "clear"
-        if allow_back: controls += ", b"
-        controls += ", q" + RESET
-        print(controls)
-
-        inp = input("> ").strip()
-        if not inp: continue
-        low = inp.lower()
-
-        if low in ("q", "quit", "exit"): return None
-        if allow_back and low in ("b", "back"): return -1
-        if low == "n": page += 1; continue
-        if low == "p": page -= 1; continue
-        if low.startswith("g "):
-            parts = low.split()
-            if len(parts) == 2 and parts[1].isdigit(): page = int(parts[1])
-            continue
-        if low == "clear": filt = None; page = 1; continue
-        if low.startswith("//"): patt = inp[2:].strip(); filt = ("regex", patt) if patt else None; page = 1; continue
-        if low.startswith("!"):  patt = inp[1:].strip();  filt = ("neg", patt)   if patt else None; page = 1; continue
-        if low.startswith("/"):  patt = inp[1:].strip();  filt = ("substr", patt)if patt else None; page = 1; continue
-        if low.startswith("id "):
-            parts = low.split()
-            if len(parts) == 2 and parts[1].isdigit():
-                k = int(parts[1])
-                if 1 <= k <= N: return k - 1
-            continue
-
-        # --- Multi Selection Logic ---
-        if multi:
-            # Check if input looks like a numeric selection string (digits, comma, hyphen, space)
-            # This prevents treating search terms like "C3K" as a failed selection attempt
-            if re.match(r"^[\d\s,-]+$", inp):
-                selected_indices = []
-                parts = inp.split(',')
-                is_range = False
-                for p in parts:
-                    p = p.strip()
-                    if not p: continue
-                    if '-' in p:
-                        is_range = True
-                        a, b = p.split('-', 1)
-                        # Handle cases like "1 - 5" or "1-5"
-                        a, b = int(a), int(b)
-                        selected_indices.extend(range(a, b + 1))
-                    else:
-                        selected_indices.append(int(p))
-                
-                # Deduplicate and validate
-                valid = [x - 1 for x in sorted(list(set(selected_indices))) if 1 <= x <= N]
-                if valid:
-                    return valid
-
-        # --- Single Selection Logic ---
-        if not multi and inp.isdigit():
-            k = int(inp)
-            if 1 <= k <= N: return k - 1
-            continue
-
-        # Default to substring filter
-        filt = ("substr", inp); page = 1
-
-
 
 
 def _parse_range(raw: str) -> Optional[Tuple[float, float]]:
@@ -815,30 +578,8 @@ def run_spectra_flow(
 
 
 
-def _parse_multi_selection(spec: str, total: int) -> list[int]:
-    """Parse 1-based IDs like "1,3-5" into unique 0-based indexes."""
-    chosen: set[int] = set()
-    for chunk in (part.strip() for part in spec.split(",")):
-        if not chunk:
-            continue
-        if "-" in chunk:
-            bounds = [part.strip() for part in chunk.split("-", 1)]
-            if len(bounds) != 2 or not bounds[0].isdigit() or not bounds[1].isdigit():
-                raise ValueError(f"Invalid range: {chunk}")
-            start, end = int(bounds[0]), int(bounds[1])
-            if start > end:
-                start, end = end, start
-            if start < 1 or end > total:
-                raise ValueError(f"Range out of bounds: {chunk}")
-            chosen.update(range(start - 1, end))
-            continue
-        if not chunk.isdigit():
-            raise ValueError(f"Invalid item: {chunk}")
-        value = int(chunk)
-        if value < 1 or value > total:
-            raise ValueError(f"Selection out of bounds: {value}")
-        chosen.add(value - 1)
-    return sorted(chosen)
+# Backward-compatible shim for code that imported this private helper.
+_parse_multi_selection = parse_multi_selection
 
 
 def run_filters_flow(base_dir: str = str(FILTER_DIR_DEFAULT)) -> None:
@@ -875,7 +616,7 @@ def run_filters_flow(base_dir: str = str(FILTER_DIR_DEFAULT)) -> None:
 
         if bulk_spec:
             try:
-                facility_indexes = _parse_multi_selection(bulk_spec, len(facilities))
+                facility_indexes = parse_multi_selection(bulk_spec, len(facilities))
             except ValueError as exc:
                 print(f"Invalid selection: {exc}")
                 continue
@@ -1159,7 +900,7 @@ def menu() -> str:
 # ------------ Main CLI ------------
 
 def main():
-    from .config import get_data_dir, show_config, set_data_dir
+    from .config import show_config, set_data_dir
 
     parser = argparse.ArgumentParser(description="SED Tools — spectra & filters")
     sub = parser.add_subparsers(dest="cmd", required=False)

--- a/sed_tools/flux_cube_tool.py
+++ b/sed_tools/flux_cube_tool.py
@@ -45,6 +45,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Iterable, List, Sequence, Tuple
 
+from .io_utils import ensure_dir
+
 FILTER_EXTENSIONS = {".dat", ".txt", ".csv"}
 
 PC_TO_M = 3.085677581e16
@@ -478,11 +480,6 @@ def plot_sed(
         plt.show()
     plt.close()
 
-
-
-def ensure_dir(path: str) -> None:
-    if path:
-        os.makedirs(path, exist_ok=True)
 
 
 def save_sed(path: str, wavelength: np.ndarray, flux: np.ndarray) -> None:

--- a/sed_tools/io_utils.py
+++ b/sed_tools/io_utils.py
@@ -1,0 +1,85 @@
+"""Shared filesystem and spectrum file helpers for SED Tools."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Union
+
+import h5py
+import numpy as np
+
+from .header_parser import parse_header
+
+PathLike = Union[str, os.PathLike[str]]
+
+
+def ensure_dir(path: PathLike) -> None:
+    """Create *path* and any missing parents if it is not empty."""
+    if path:
+        Path(path).mkdir(parents=True, exist_ok=True)
+
+
+def list_txt_spectra(model_dir: PathLike) -> list[str]:
+    """Return sorted ``.txt`` spectrum file names in *model_dir*."""
+    return sorted(
+        entry.name
+        for entry in Path(model_dir).iterdir()
+        if entry.is_file() and entry.suffix.lower() == ".txt"
+    )
+
+
+def load_txt_spectrum(txt_path: PathLike) -> tuple[np.ndarray, np.ndarray]:
+    """Load wavelength and flux columns from a two-column text spectrum."""
+    wavelength: list[float] = []
+    flux: list[float] = []
+    with Path(txt_path).open("r", encoding="utf-8", errors="ignore") as handle:
+        for line in handle:
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            parts = stripped.split()
+            if len(parts) < 2:
+                continue
+            wavelength.append(float(parts[0]))
+            flux.append(float(parts[1]))
+    return np.asarray(wavelength, dtype=float), np.asarray(flux, dtype=float)
+
+
+def build_h5_bundle_from_txt(model_dir: PathLike, out_h5: PathLike) -> None:
+    """Bundle all text spectra in *model_dir* into one HDF5 file."""
+    model_path = Path(model_dir)
+    out_path = Path(out_h5)
+    txt_files = list_txt_spectra(model_path)
+    if not txt_files:
+        print(f"[H5 bundle] No .txt spectra found in {model_path}; skipping.")
+        return
+
+    ensure_dir(out_path.parent)
+    with h5py.File(out_path, "w") as h5:
+        spectra_group = h5.create_group("spectra")
+        for filename in txt_files:
+            path = model_path / filename
+            wavelength, flux = load_txt_spectrum(path)
+            if wavelength.size == 0 or flux.size == 0:
+                print(f"[H5 bundle] Empty or invalid spectrum: {filename}")
+                continue
+
+            group = spectra_group.create_group(filename)
+            group.create_dataset("lambda", data=wavelength, dtype="f8")
+            group.create_dataset("flux", data=flux, dtype="f8")
+
+            metadata = parse_header(path)
+            teff = metadata.get("teff", np.nan)
+            logg = metadata.get("logg", np.nan)
+            metallicity = metadata.get("metallicity", np.nan)
+            if not np.isnan(teff):
+                group.attrs["teff"] = teff
+            if not np.isnan(logg):
+                group.attrs["logg"] = logg
+            if not np.isnan(metallicity):
+                group.attrs["feh"] = metallicity
+            for key, value in metadata.items():
+                group.attrs[f"raw:{key}"] = value
+
+    print(f"[H5 bundle] Wrote {out_path}")

--- a/sed_tools/svo_filter_grabber.py
+++ b/sed_tools/svo_filter_grabber.py
@@ -7,13 +7,13 @@ import sys
 import textwrap
 import urllib.parse
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Sequence, Set
+from typing import Dict, List, Optional, Sequence
 
 import requests
 from astroquery.svo_fps import SvoFps
 from bs4 import BeautifulSoup
 
-from . import _prompt_choice
+from .ui_utils import _prompt_choice, parse_multi_selection
 
 SvoFps.TIMEOUT = 300  # give SVO a generous timeout
 
@@ -241,33 +241,6 @@ def _clean_path(value: str) -> str:
 def _clean_filename(value: str) -> str:
     return _clean_path(value).replace(" ", "_")
 
-
-def parse_multi_selection(spec: str, total: int) -> List[int]:
-    """Parse a 1-based comma-separated/range selection into unique 0-based indices."""
-    chosen: Set[int] = set()
-    for chunk in (part.strip() for part in spec.split(",")):
-        if not chunk:
-            continue
-        if "-" in chunk:
-            bounds = [p.strip() for p in chunk.split("-", 1)]
-            if len(bounds) != 2 or not bounds[0].isdigit() or not bounds[1].isdigit():
-                raise ValueError(f"Invalid range: {chunk}")
-            start, end = int(bounds[0]), int(bounds[1])
-            if start > end:
-                start, end = end, start
-            if start < 1 or end > total:
-                raise ValueError(f"Range out of bounds: {chunk}")
-            chosen.update(range(start - 1, end))
-            continue
-
-        if not chunk.isdigit():
-            raise ValueError(f"Invalid item: {chunk}")
-        value = int(chunk)
-        if value < 1 or value > total:
-            raise ValueError(f"Selection out of bounds: {value}")
-        chosen.add(value - 1)
-
-    return sorted(chosen)
 
 
 

--- a/sed_tools/ui_utils.py
+++ b/sed_tools/ui_utils.py
@@ -180,3 +180,28 @@ def _prompt_choice(
 
         # Default to substring filter
         filt = ("substr", inp); page = 1
+
+def parse_multi_selection(spec: str, total: int) -> list[int]:
+    """Parse 1-based comma/range selections into unique 0-based indexes."""
+    chosen: set[int] = set()
+    for chunk in (part.strip() for part in spec.split(",")):
+        if not chunk:
+            continue
+        if "-" in chunk:
+            bounds = [part.strip() for part in chunk.split("-", 1)]
+            if len(bounds) != 2 or not bounds[0].isdigit() or not bounds[1].isdigit():
+                raise ValueError(f"Invalid range: {chunk}")
+            start, end = int(bounds[0]), int(bounds[1])
+            if start > end:
+                start, end = end, start
+            if start < 1 or end > total:
+                raise ValueError(f"Range out of bounds: {chunk}")
+            chosen.update(range(start - 1, end))
+            continue
+        if not chunk.isdigit():
+            raise ValueError(f"Invalid item: {chunk}")
+        value = int(chunk)
+        if value < 1 or value > total:
+            raise ValueError(f"Selection out of bounds: {value}")
+        chosen.add(value - 1)
+    return sorted(chosen)

--- a/tests/test_filter_api.py
+++ b/tests/test_filter_api.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+
+from sed_tools.api import Filters
+
+
+def test_filters_query_local_ignores_empty_filter_dirs(tmp_path, monkeypatch):
+    empty = tmp_path / "WISE" / "WISE"
+    empty.mkdir(parents=True)
+    (empty / "WISE").write_text("W1.dat\nW2.dat\n")
+
+    monkeypatch.setattr(Filters, "_filter_root", tmp_path)
+
+    assert Filters.query(include_local=True, include_remote=False) == []
+
+
+def test_filters_query_local_reports_dat_filter_dirs(tmp_path, monkeypatch):
+    filt_dir = tmp_path / "WISE" / "WISE"
+    filt_dir.mkdir(parents=True)
+    (filt_dir / "W1.dat").write_text("Wavelength,Transmission\n1,1\n")
+    (filt_dir / "W2.dat").write_text("Wavelength,Transmission\n2,1\n")
+
+    monkeypatch.setattr(Filters, "_filter_root", tmp_path)
+
+    assert Filters.query(include_local=True, include_remote=False) == [
+        {
+            "facility": "WISE",
+            "instrument": "WISE",
+            "n_filters": 2,
+            "is_local": True,
+        }
+    ]
+
+
+def test_remove_empty_filter_dir_removes_only_partial_leaf(tmp_path):
+    path = tmp_path / "WISE" / "WISE"
+    path.mkdir(parents=True)
+    (path / "WISE").write_text("W1.dat\n")
+
+    Filters._remove_empty_filter_dir(path)
+
+    assert not path.exists()
+    assert not (tmp_path / "WISE").exists()
+
+
+def test_remove_empty_filter_dir_keeps_real_filter_dir(tmp_path):
+    path = tmp_path / "WISE" / "WISE"
+    path.mkdir(parents=True)
+    (path / "W1.dat").write_text("Wavelength,Transmission\n1,1\n")
+
+    Filters._remove_empty_filter_dir(path)
+
+    assert path.exists()
+    assert (path / "W1.dat").exists()

--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -1,0 +1,46 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import h5py
+import numpy as np
+import pytest
+
+from sed_tools.io_utils import build_h5_bundle_from_txt, load_txt_spectrum
+
+
+def test_load_txt_spectrum_rejects_malformed_numeric_data(tmp_path):
+    spectrum = tmp_path / "bad.txt"
+    spectrum.write_text("# comment\n4000 1.0\nnot-a-number 2.0\n")
+
+    with pytest.raises(ValueError):
+        load_txt_spectrum(spectrum)
+
+
+def test_build_h5_bundle_propagates_spectrum_parse_errors(tmp_path):
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+    (model_dir / "bad.txt").write_text("4000 1.0\n5000 not-a-number\n")
+
+    with pytest.raises(ValueError):
+        build_h5_bundle_from_txt(model_dir, model_dir / "model.h5")
+
+
+def test_build_h5_bundle_writes_valid_spectra(tmp_path):
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+    (model_dir / "good.txt").write_text(
+        "# teff = 5777\n# logg = 4.44\n# metallicity = 0.0\n4000 1.0\n5000 2.0\n"
+    )
+    out_h5 = model_dir / "model.h5"
+
+    build_h5_bundle_from_txt(model_dir, out_h5)
+
+    with h5py.File(out_h5, "r") as h5:
+        group = h5["spectra/good.txt"]
+        assert np.allclose(group["lambda"][:], [4000.0, 5000.0])
+        assert np.allclose(group["flux"][:], [1.0, 2.0])
+        assert group.attrs["teff"] == 5777.0


### PR DESCRIPTION
### Motivation
- Reduce startup cost and duplication by extracting filesystem and text-spectrum helpers from package init and CLI into a dedicated `io_utils` module.
- Centralize interactive/UI helpers into `ui_utils` and avoid heavy CLI imports when `sed_tools` is imported as a library.
- Improve package metadata exposure by deriving `__version__` from installed distribution metadata.

### Description
- Add `sed_tools/io_utils.py` with `ensure_dir`, `list_txt_spectra`, `load_txt_spectrum`, and `build_h5_bundle_from_txt` and update callers to use these helpers (CLI, `api.Catalog.write`, `flux_cube_tool`, etc.).
- Simplify `sed_tools/__init__.py` by removing large inline utilities and bundling lightweight shims (`run_rebuild_flow`, `run_spectra_flow`, `run_filters_flow`, `run_combine_flow`, `menu`) that delegate to `sed_tools.cli` to avoid heavy imports at package import time, and export the new IO helpers and shims in `__all__`.
- Resolve package version at import via `importlib.metadata.version('sed-tools')` with a fallback default `__version__`.
- Rework `sed_tools/cli.py`, `svo_filter_grabber.py`, and `ui_utils.py` to reuse the centralized helpers and move/keep multi-selection parsing in `ui_utils` as `parse_multi_selection`, with a backward-compatible alias used where needed.
- Add unit tests `tests/test_io_utils.py` that validate text-spectrum parsing and HDF5 bundling behavior.

### Testing
- Ran the new unit tests with `pytest tests/test_io_utils.py`, which executed the spectrum loader and HDF5 bundling tests and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18a4a5b9f08321ba0dddc6434b4444)