### PR TITLE
Add filter-set combiner with CLI, API and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,26 @@ data/filters/Generic/Johnson/
 └── Johnson         # Index file for MESA
 ```
 
+Downloaded filter sets can be combined without rebuilding spectra or flux cubes, because a filter set is only a directory of ``*.dat`` curves plus the MESA index file whose lines list those curves. The helper below copies the selected curves into a new instrument folder and writes the matching index file automatically.
+
+```bash
+# Create data/filters/Combined/Gaia2MASS/ with a Gaia2MASS index file
+sed-tools filters-combine Gaia2MASS GAIA/GAIA 2MASS/2MASS
+
+# Pick custom MESA-facing labels and fail on duplicate band names
+sed-tools filters-combine optical_ir Generic/Johnson 2MASS/2MASS \
+  --facility Custom --instrument optical_ir --on-conflict error
+```
+
+The same operation is available from Python:
+
+```python
+from sed_tools.api import Filters
+
+combined = Filters.combine("Gaia2MASS", "GAIA/GAIA", "2MASS/2MASS")
+print(combined)
+```
+
 ---
 
 ### `sed-tools rebuild`

--- a/sed_tools/api.py
+++ b/sed_tools/api.py
@@ -1839,6 +1839,32 @@ class Filters:
 
         raise ValueError(f"Could not download filters for {facility}/{instrument}")
 
+    @classmethod
+    def combine(
+        cls,
+        output: Union[str, Path],
+        *inputs: Union[str, Path],
+        filter_root: Optional[Union[str, Path]] = None,
+        facility: Optional[str] = None,
+        instrument: Optional[str] = None,
+        on_conflict: str = "rename",
+    ) -> Path:
+        """Combine existing filter sets into one MESA-compatible set.
+
+        This is a convenience wrapper around
+        :func:`sed_tools.combine_filters.combine_filter_sets`.
+        """
+        from .combine_filters import combine_filter_sets
+
+        return combine_filter_sets(
+            output,
+            inputs,
+            filter_root=filter_root or cls._filter_root,
+            facility=facility,
+            instrument=instrument,
+            on_conflict=on_conflict,
+        )
+
 
 # =============================================================================
 # Convenience exports

--- a/sed_tools/cli.py
+++ b/sed_tools/cli.py
@@ -1233,6 +1233,16 @@ def main():
     fp.add_argument("--base", default=str(FILTER_DIR_DEFAULT),
                     help="Output base for filters")
 
+    fcp = sub.add_parser("filters-combine", help="Combine filter sets into one MESA-compatible instrument")
+    fcp.add_argument("output", help="Output name or Facility/Instrument path for the combined filter set")
+    fcp.add_argument("inputs", nargs="+", help="Filter-set directories or .dat files to combine")
+    fcp.add_argument("--base", default=str(FILTER_DIR_DEFAULT),
+                     help="Base filter directory")
+    fcp.add_argument("--facility", default=None, help="Output facility label (default: Combined)")
+    fcp.add_argument("--instrument", default=None, help="Output instrument/index-file name")
+    fcp.add_argument("--on-conflict", choices=["rename", "overwrite", "error"], default="rename",
+                     help="How duplicate filter filenames are handled")
+
     # rebuild
     rp = sub.add_parser("rebuild", help="Rebuild lookup table + HDF5 + flux cube")
     rp.add_argument("--base", default=str(STELLAR_DIR_DEFAULT),
@@ -1338,6 +1348,17 @@ def main():
         )
     elif args.cmd == "filters":
         run_filters_flow(base_dir=args.base)
+    elif args.cmd == "filters-combine":
+        from .combine_filters import combine_filter_sets
+        out = combine_filter_sets(
+            args.output,
+            args.inputs,
+            filter_root=args.base,
+            facility=args.facility,
+            instrument=args.instrument,
+            on_conflict=args.on_conflict,
+        )
+        print(f"[filters] Combined filter set written to {out}")
     elif args.cmd == "rebuild":
         run_rebuild_flow(
             base_dir=args.base,

--- a/sed_tools/combine_filters.py
+++ b/sed_tools/combine_filters.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""
+Combine multiple photometric filter sets into one MESA-compatible set.
+
+Unlike stellar atmosphere combination, filter combination does not need a flux
+cube. A filter set is just a directory of ``*.dat`` transmission curves plus an
+index file whose contents list those curve filenames.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+from pathlib import Path
+from typing import List, Optional, Sequence, Union
+
+from .models import FILTER_DIR_DEFAULT
+
+PathLike = Union[str, os.PathLike[str]]
+
+
+def find_filter_sets(base_dir: Optional[PathLike] = None) -> List[Path]:
+    """Find local filter-set directories containing ``*.dat`` files."""
+    root = Path(base_dir) if base_dir is not None else FILTER_DIR_DEFAULT
+    if not root.exists():
+        return []
+
+    filter_sets: List[Path] = []
+    for path in sorted(root.rglob("*")):
+        if not path.is_dir():
+            continue
+        if any(child.is_file() and child.suffix.lower() == ".dat" for child in path.iterdir()):
+            filter_sets.append(path)
+    return filter_sets
+
+
+def resolve_output_path(
+    output: PathLike,
+    base_dir: PathLike,
+    *,
+    facility: Optional[str] = None,
+    instrument: Optional[str] = None,
+) -> Path:
+    """Resolve a friendly output name into a filter-set directory path."""
+    output_path = Path(output)
+    root = Path(base_dir)
+
+    if output_path.is_absolute():
+        return output_path
+    if facility or instrument:
+        return root / (facility or "Combined") / (instrument or output_path.name)
+    if len(output_path.parts) == 1:
+        return root / "Combined" / output_path.name
+    return root / output_path
+
+
+def resolve_filter_sources(source: PathLike, base_dir: PathLike) -> List[Path]:
+    """Resolve one input into concrete ``*.dat`` files."""
+    source_path = Path(source)
+    root = Path(base_dir)
+    candidates = [source_path] if source_path.is_absolute() else [source_path, root / source_path]
+
+    for candidate in candidates:
+        if candidate.is_file() and candidate.suffix.lower() == ".dat":
+            return [candidate]
+        if candidate.is_dir():
+            files = sorted(
+                child for child in candidate.iterdir()
+                if child.is_file() and child.suffix.lower() == ".dat"
+            )
+            if files:
+                return files
+
+            child_dirs = sorted(child for child in candidate.iterdir() if child.is_dir())
+            if len(child_dirs) == 1:
+                nested = resolve_filter_sources(child_dirs[0], root)
+                if nested:
+                    return nested
+
+    raise FileNotFoundError(f"Could not find .dat filters for input: {source}")
+
+
+def unique_filter_target(output_dir: Path, source_file: Path) -> Path:
+    """Choose a non-conflicting output name for a duplicate filter file."""
+    parent_names = [parent.name for parent in source_file.parents[:2] if parent.name]
+    prefix = "_".join(reversed(parent_names))
+    stem = f"{prefix}_{source_file.stem}" if prefix else source_file.stem
+    target = output_dir / f"{stem}{source_file.suffix}"
+
+    counter = 2
+    while target.exists():
+        target = output_dir / f"{stem}_{counter}{source_file.suffix}"
+        counter += 1
+    return target
+
+
+def write_filter_index(filter_dir: Path, instrument: str) -> Path:
+    """Write the MESA index file for all ``*.dat`` files in ``filter_dir``."""
+    dat_files = sorted(child.name for child in filter_dir.glob("*.dat") if child.is_file())
+    index_path = filter_dir / instrument
+    index_path.write_text("\n".join(dat_files) + "\n", encoding="utf-8")
+    return index_path
+
+
+def combine_filter_sets(
+    output: PathLike,
+    inputs: Sequence[PathLike],
+    *,
+    filter_root: Optional[PathLike] = None,
+    facility: Optional[str] = None,
+    instrument: Optional[str] = None,
+    on_conflict: str = "rename",
+) -> Path:
+    """Combine filter files or filter-set directories into one filter set."""
+    if not inputs:
+        raise ValueError("Provide at least one filter file or filter-set directory to combine")
+
+    mode = on_conflict.lower()
+    if mode not in {"rename", "overwrite", "error"}:
+        raise ValueError("on_conflict must be one of: 'rename', 'overwrite', 'error'")
+
+    root = Path(filter_root) if filter_root is not None else FILTER_DIR_DEFAULT
+    output_dir = resolve_output_path(output, root, facility=facility, instrument=instrument)
+    output_instrument = instrument or output_dir.name
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    copied: List[str] = []
+    for source in inputs:
+        for source_file in resolve_filter_sources(source, root):
+            target = output_dir / source_file.name
+            if target.exists() and target.resolve() != source_file.resolve():
+                if mode == "error":
+                    raise FileExistsError(f"Filter name conflict while combining: {source_file.name}")
+                if mode == "rename":
+                    target = unique_filter_target(output_dir, source_file)
+
+            if target.resolve() != source_file.resolve():
+                shutil.copy2(source_file, target)
+            copied.append(target.name)
+
+    if not copied:
+        raise ValueError("No .dat filter files were found in the supplied inputs")
+
+    write_filter_index(output_dir, output_instrument)
+    return output_dir
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Combine filter sets into one MESA-compatible instrument"
+    )
+    parser.add_argument("output", help="Output name or Facility/Instrument path")
+    parser.add_argument("inputs", nargs="+", help="Filter-set directories or .dat files")
+    parser.add_argument("--base", default=str(FILTER_DIR_DEFAULT), help="Base filter directory")
+    parser.add_argument("--facility", default=None, help="Output facility label")
+    parser.add_argument("--instrument", default=None, help="Output instrument/index-file name")
+    parser.add_argument(
+        "--on-conflict",
+        choices=["rename", "overwrite", "error"],
+        default="rename",
+        help="How duplicate filter filenames are handled",
+    )
+
+    args = parser.parse_args(argv)
+    output_dir = combine_filter_sets(
+        args.output,
+        args.inputs,
+        filter_root=args.base,
+        facility=args.facility,
+        instrument=args.instrument,
+        on_conflict=args.on_conflict,
+    )
+    print(f"[filters] Combined filter set written to {output_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_filter_api.py
+++ b/tests/test_filter_api.py
@@ -51,3 +51,47 @@ def test_remove_empty_filter_dir_keeps_real_filter_dir(tmp_path):
 
     assert path.exists()
     assert (path / "W1.dat").exists()
+
+
+def test_filters_combine_creates_mesa_index_file(tmp_path):
+    gaia = tmp_path / "GAIA" / "GAIA"
+    twomass = tmp_path / "2MASS" / "2MASS"
+    gaia.mkdir(parents=True)
+    twomass.mkdir(parents=True)
+    (gaia / "G.dat").write_text("Wavelength,Transmission\n5000,1\n")
+    (twomass / "J.dat").write_text("Wavelength,Transmission\n12000,1\n")
+
+    out = Filters.combine("Gaia2MASS", "GAIA/GAIA", "2MASS/2MASS", filter_root=tmp_path)
+
+    assert out == tmp_path / "Combined" / "Gaia2MASS"
+    assert sorted(p.name for p in out.glob("*.dat")) == ["G.dat", "J.dat"]
+    assert (out / "Gaia2MASS").read_text().splitlines() == ["G.dat", "J.dat"]
+
+
+def test_filters_combine_renames_conflicting_filter_names(tmp_path):
+    first = tmp_path / "A" / "Inst"
+    second = tmp_path / "B" / "Inst"
+    first.mkdir(parents=True)
+    second.mkdir(parents=True)
+    (first / "V.dat").write_text("Wavelength,Transmission\n1,1\n")
+    (second / "V.dat").write_text("Wavelength,Transmission\n2,1\n")
+
+    out = Filters.combine("Combined/AB", first, second, filter_root=tmp_path)
+
+    names = sorted(p.name for p in out.glob("*.dat"))
+    assert names == ["B_Inst_V.dat", "V.dat"]
+    assert (out / "AB").read_text().splitlines() == names
+
+
+def test_combine_filter_sets_module_function_matches_api_layout(tmp_path):
+    from sed_tools.combine_filters import combine_filter_sets
+
+    source = tmp_path / "Generic" / "Johnson"
+    source.mkdir(parents=True)
+    (source / "B.dat").write_text("Wavelength,Transmission\n1,1\n")
+
+    out = combine_filter_sets("Optical", ["Generic/Johnson"], filter_root=tmp_path)
+
+    assert out == tmp_path / "Combined" / "Optical"
+    assert (out / "B.dat").exists()
+    assert (out / "Optical").read_text().splitlines() == ["B.dat"]


### PR DESCRIPTION
### Motivation

- Provide a simple way to combine downloaded photometric filter sets into a single MESA-compatible instrument so users can reuse filter collections without rebuilding spectra or flux cubes. 
- Offer both CLI and Python API access for convenient automation and scripting workflows. 

### Description

- Add a new module `sed_tools/combine_filters.py` that implements `combine_filter_sets` to merge `.dat` filter files, resolve inputs, handle name conflicts, and write a MESA index file. 
- Expose the functionality in the public API via `Filters.combine(...)` as a thin wrapper around `combine_filter_sets`. 
- Add a `filters-combine` CLI subcommand to `sed_tools/cli.py` with arguments `output`, `inputs`, `--base`, `--facility`, `--instrument`, and `--on-conflict`. 
- Update `README.md` to document the `sed-tools filters-combine` usage and provide example shell and Python snippets. 

### Testing

- Added unit tests in `tests/test_filter_api.py` covering index file creation, conflict renaming, and module/API parity, and ran `pytest tests/test_filter_api.py` which passed. 
- The combine utility was exercised via the new CLI/`Filters.combine` wrapper in tests and produced the expected directory layout and index file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4573d42cc8832189fae291b920d625)