### PR TITLE
Add filter-set combination utility, CLI command, and docs/tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,26 @@ data/filters/Generic/Johnson/
 └── Johnson         # Index file for MESA
 ```
 
+Downloaded filter sets can be combined without rebuilding spectra or flux cubes, because a filter set is only a directory of ``*.dat`` curves plus the MESA index file whose lines list those curves. The helper below copies the selected curves into a new instrument folder and writes the matching index file automatically.
+
+```bash
+# Create data/filters/Combined/Gaia2MASS/ with a Gaia2MASS index file
+sed-tools filters-combine Gaia2MASS GAIA/GAIA 2MASS/2MASS
+
+# Pick custom MESA-facing labels and fail on duplicate band names
+sed-tools filters-combine optical_ir Generic/Johnson 2MASS/2MASS \
+  --facility Custom --instrument optical_ir --on-conflict error
+```
+
+The same operation is available from Python:
+
+```python
+from sed_tools.api import Filters
+
+combined = Filters.combine("Gaia2MASS", "GAIA/GAIA", "2MASS/2MASS")
+print(combined)
+```
+
 ---
 
 ### `sed-tools rebuild`

--- a/sed_tools/api.py
+++ b/sed_tools/api.py
@@ -1839,6 +1839,32 @@ class Filters:
 
         raise ValueError(f"Could not download filters for {facility}/{instrument}")
 
+    @classmethod
+    def combine(
+        cls,
+        output: Union[str, Path],
+        *inputs: Union[str, Path],
+        filter_root: Optional[Union[str, Path]] = None,
+        facility: Optional[str] = None,
+        instrument: Optional[str] = None,
+        on_conflict: str = "rename",
+    ) -> Path:
+        """Combine existing filter sets into one MESA-compatible set.
+
+        This is a convenience wrapper around
+        :func:`sed_tools.combine_filters.combine_filter_sets`.
+        """
+        from .combine_filters import combine_filter_sets
+
+        return combine_filter_sets(
+            output,
+            inputs,
+            filter_root=filter_root or cls._filter_root,
+            facility=facility,
+            instrument=instrument,
+            on_conflict=on_conflict,
+        )
+
 
 # =============================================================================
 # Convenience exports

--- a/sed_tools/cli.py
+++ b/sed_tools/cli.py
@@ -22,6 +22,7 @@ import re
 import shutil
 import sys
 import textwrap
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
 import h5py
@@ -992,6 +993,85 @@ def run_filters_flow(base_dir: str = str(FILTER_DIR_DEFAULT)) -> None:
                 break
 
 
+def run_filter_combine_flow(base_dir: str = str(FILTER_DIR_DEFAULT)) -> None:
+    """Interactive wizard for combining local filter sets."""
+    from .combine_filters import combine_filter_sets, find_filter_sets
+
+    print("\nCombine photometric filter sets")
+    print("This creates one MESA-compatible filter folder and index file from existing .dat files.")
+
+    chosen_base = input(f"Filter base directory [{base_dir}]: ").strip() or base_dir
+    filter_sets = find_filter_sets(chosen_base)
+    if not filter_sets:
+        print(f"No local filter sets containing .dat files were found under {chosen_base}.")
+        print("Download filters first with option 2, or run `sed-tools filters`.")
+        return
+
+    class _FilterSetOption:
+        def __init__(self, path: Path, root: Path) -> None:
+            self.path = path
+            try:
+                rel = path.relative_to(root)
+            except ValueError:
+                rel = path
+            n_filters = len(list(path.glob("*.dat")))
+            self.label = f"{rel} ({n_filters} filters)"
+
+    root = Path(chosen_base)
+    options = [_FilterSetOption(path, root) for path in filter_sets]
+    selected = _prompt_choice(
+        options,
+        "Local filter sets to combine",
+        multi=True,
+        page_size=50,
+        max_cols=2,
+    )
+    if selected is None or selected == []:
+        print("No filter sets selected.")
+        return
+    if isinstance(selected, int):
+        selected = [selected]
+
+    selected_paths = [options[i].path for i in selected]
+    print("\nSelected filter sets:")
+    for path in selected_paths:
+        print(f"  - {path}")
+
+    default_name = "_".join(path.name for path in selected_paths[:3]) or "CombinedFilters"
+    output = input(f"Combined instrument name [{default_name}]: ").strip() or default_name
+    facility = input("Output facility label [Combined]: ").strip() or None
+    instrument = input(f"Output index/instrument name [{output}]: ").strip() or None
+
+    conflict = input("Duplicate band names: rename, overwrite, or error? [rename]: ").strip().lower() or "rename"
+    while conflict not in {"rename", "overwrite", "error"}:
+        conflict = input("Please enter rename, overwrite, or error [rename]: ").strip().lower() or "rename"
+
+    print("\nAbout to create a combined filter set:")
+    print(f"  Base      : {chosen_base}")
+    print(f"  Output    : {output}")
+    print(f"  Facility  : {facility or 'Combined'}")
+    print(f"  Instrument: {instrument or output}")
+    print(f"  Conflicts : {conflict}")
+    confirm = input("Proceed? [Y/n] ").strip().lower()
+    if confirm and not confirm.startswith("y"):
+        print("Cancelled.")
+        return
+
+    out = combine_filter_sets(
+        output,
+        selected_paths,
+        filter_root=chosen_base,
+        facility=facility,
+        instrument=instrument,
+        on_conflict=conflict,
+    )
+    dat_count = len(list(out.glob("*.dat")))
+    index_name = instrument or out.name
+    print(f"\n[filters] Combined {dat_count} filters into {out}")
+    print(f"[filters] Wrote MESA index file: {out / index_name}")
+    print("Use this path as the MESA instrument/filter-set directory.")
+
+
 def run_ml_generator_flow(
     base_dir: str = STELLAR_DIR_DEFAULT,
     models_dir: str = "models"
@@ -1176,35 +1256,39 @@ def run_import_flow(base_dir: str = str(STELLAR_DIR_DEFAULT)) -> None:
 
 def menu() -> str:
     print("\nWhat would you like to run?")
-    print("1) Spectra (NJM / SVO / MSG / MAST)")
-    print("2) Filters (NJM / SVO)")
-    print("3) Rebuild (lookup + HDF5 + flux cube)")
-    print("4) Combine grids into omni grid")
-    print("5) ML SED Completer (train/extend incomplete SEDs)")
-    print("6) ML SED Generator (generate SEDs from parameters)")
-    print("7) Grid Densifier (fill coarse Teff gaps)")
-    print("8) MESA Prepare (export a sub-variant for MESA)")
-    print("9) Config (show/set data directory)")
-    print("10) Coverage (parameter-space summary + plot)")
-    print("11) Import a local grid into the pipeline")
+    print("\nFilters")
+    print("1) Download filters (NJM / SVO)")
+    print("2) Combine filter sets")
+    print("\nAtmosphere grids")
+    print("3) Download/build spectra (NJM / SVO / MSG / MAST)")
+    print("4) Rebuild atmosphere products (lookup + HDF5 + flux cube)")
+    print("5) Combine atmosphere grids into omni grid")
+    print("6) Coverage (parameter-space summary + plot)")
+    print("7) Import a local atmosphere grid")
+    print("8) Grid Densifier (fill coarse Teff gaps)")
+    print("9) ML SED Completer (train/extend incomplete SEDs)")
+    print("10) ML SED Generator (generate SEDs from parameters)")
+    print("\nMisc / export")
+    print("11) MESA Prepare (export a sub-variant for MESA)")
+    print("12) Config (show/set data directory)")
     print("0) Quit")
     choice = input("> ").strip()
     mapping = {
-        "1": "spectra",
-        "2": "filters",
-        "3": "rebuild",
-        "4": "combine",
-        "5": "ml_completer",
-        "6": "ml_generator",
-        "7": "grid_densifier",
-        "8": "mesa_prepare",
-        "9": "config",
-        "10": "coverage",
-        "11": "import",
+        "1": "filters",
+        "2": "filters_combine",
+        "3": "spectra",
+        "4": "rebuild",
+        "5": "combine",
+        "6": "coverage",
+        "7": "import",
+        "8": "grid_densifier",
+        "9": "ml_completer",
+        "10": "ml_generator",
+        "11": "mesa_prepare",
+        "12": "config",
         "0": "quit"
     }
     return mapping.get(choice, "")
-
 
 # ------------ Main CLI ------------
 
@@ -1232,6 +1316,16 @@ def main():
     fp = sub.add_parser("filters", help="Download SVO filters")
     fp.add_argument("--base", default=str(FILTER_DIR_DEFAULT),
                     help="Output base for filters")
+
+    fcp = sub.add_parser("filters-combine", help="Combine filter sets into one MESA-compatible instrument")
+    fcp.add_argument("output", help="Output name or Facility/Instrument path for the combined filter set")
+    fcp.add_argument("inputs", nargs="+", help="Filter-set directories or .dat files to combine")
+    fcp.add_argument("--base", default=str(FILTER_DIR_DEFAULT),
+                     help="Base filter directory")
+    fcp.add_argument("--facility", default=None, help="Output facility label (default: Combined)")
+    fcp.add_argument("--instrument", default=None, help="Output instrument/index-file name")
+    fcp.add_argument("--on-conflict", choices=["rename", "overwrite", "error"], default="rename",
+                     help="How duplicate filter filenames are handled")
 
     # rebuild
     rp = sub.add_parser("rebuild", help="Rebuild lookup table + HDF5 + flux cube")
@@ -1338,6 +1432,17 @@ def main():
         )
     elif args.cmd == "filters":
         run_filters_flow(base_dir=args.base)
+    elif args.cmd == "filters-combine":
+        from .combine_filters import combine_filter_sets
+        out = combine_filter_sets(
+            args.output,
+            args.inputs,
+            filter_root=args.base,
+            facility=args.facility,
+            instrument=args.instrument,
+            on_conflict=args.on_conflict,
+        )
+        print(f"[filters] Combined filter set written to {out}")
     elif args.cmd == "rebuild":
         run_rebuild_flow(
             base_dir=args.base,
@@ -1424,6 +1529,8 @@ def main():
                 run_spectra_flow(source="all")
             elif choice == "filters":
                 run_filters_flow()
+            elif choice == "filters_combine":
+                run_filter_combine_flow()
             elif choice == "rebuild":
                 run_rebuild_flow()
             elif choice == "combine":

--- a/sed_tools/combine_filters.py
+++ b/sed_tools/combine_filters.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""
+Combine multiple photometric filter sets into one MESA-compatible set.
+
+Unlike stellar atmosphere combination, filter combination does not need a flux
+cube. A filter set is just a directory of ``*.dat`` transmission curves plus an
+index file whose contents list those curve filenames.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+from pathlib import Path
+from typing import List, Optional, Sequence, Union
+
+from .models import FILTER_DIR_DEFAULT
+
+PathLike = Union[str, os.PathLike[str]]
+
+
+def find_filter_sets(base_dir: Optional[PathLike] = None) -> List[Path]:
+    """Find local filter-set directories containing ``*.dat`` files."""
+    root = Path(base_dir) if base_dir is not None else FILTER_DIR_DEFAULT
+    if not root.exists():
+        return []
+
+    filter_sets: List[Path] = []
+    for path in sorted(root.rglob("*")):
+        if not path.is_dir():
+            continue
+        if any(child.is_file() and child.suffix.lower() == ".dat" for child in path.iterdir()):
+            filter_sets.append(path)
+    return filter_sets
+
+
+def resolve_output_path(
+    output: PathLike,
+    base_dir: PathLike,
+    *,
+    facility: Optional[str] = None,
+    instrument: Optional[str] = None,
+) -> Path:
+    """Resolve a friendly output name into a filter-set directory path."""
+    output_path = Path(output)
+    root = Path(base_dir)
+
+    if output_path.is_absolute():
+        return output_path
+    if facility or instrument:
+        return root / (facility or "Combined") / (instrument or output_path.name)
+    if len(output_path.parts) == 1:
+        return root / "Combined" / output_path.name
+    return root / output_path
+
+
+def resolve_filter_sources(source: PathLike, base_dir: PathLike) -> List[Path]:
+    """Resolve one input into concrete ``*.dat`` files."""
+    source_path = Path(source)
+    root = Path(base_dir)
+    candidates = [source_path] if source_path.is_absolute() else [source_path, root / source_path]
+
+    for candidate in candidates:
+        if candidate.is_file() and candidate.suffix.lower() == ".dat":
+            return [candidate]
+        if candidate.is_dir():
+            files = sorted(
+                child for child in candidate.iterdir()
+                if child.is_file() and child.suffix.lower() == ".dat"
+            )
+            if files:
+                return files
+
+            child_dirs = sorted(child for child in candidate.iterdir() if child.is_dir())
+            if len(child_dirs) == 1:
+                nested = resolve_filter_sources(child_dirs[0], root)
+                if nested:
+                    return nested
+
+    raise FileNotFoundError(f"Could not find .dat filters for input: {source}")
+
+
+def unique_filter_target(output_dir: Path, source_file: Path) -> Path:
+    """Choose a non-conflicting output name for a duplicate filter file."""
+    parent_names = [parent.name for parent in source_file.parents[:2] if parent.name]
+    prefix = "_".join(reversed(parent_names))
+    stem = f"{prefix}_{source_file.stem}" if prefix else source_file.stem
+    target = output_dir / f"{stem}{source_file.suffix}"
+
+    counter = 2
+    while target.exists():
+        target = output_dir / f"{stem}_{counter}{source_file.suffix}"
+        counter += 1
+    return target
+
+
+def write_filter_index(filter_dir: Path, instrument: str) -> Path:
+    """Write the MESA index file for all ``*.dat`` files in ``filter_dir``."""
+    dat_files = sorted(child.name for child in filter_dir.glob("*.dat") if child.is_file())
+    index_path = filter_dir / instrument
+    index_path.write_text("\n".join(dat_files) + "\n", encoding="utf-8")
+    return index_path
+
+
+def combine_filter_sets(
+    output: PathLike,
+    inputs: Sequence[PathLike],
+    *,
+    filter_root: Optional[PathLike] = None,
+    facility: Optional[str] = None,
+    instrument: Optional[str] = None,
+    on_conflict: str = "rename",
+) -> Path:
+    """Combine filter files or filter-set directories into one filter set."""
+    if not inputs:
+        raise ValueError("Provide at least one filter file or filter-set directory to combine")
+
+    mode = on_conflict.lower()
+    if mode not in {"rename", "overwrite", "error"}:
+        raise ValueError("on_conflict must be one of: 'rename', 'overwrite', 'error'")
+
+    root = Path(filter_root) if filter_root is not None else FILTER_DIR_DEFAULT
+    output_dir = resolve_output_path(output, root, facility=facility, instrument=instrument)
+    output_instrument = instrument or output_dir.name
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    copied: List[str] = []
+    for source in inputs:
+        for source_file in resolve_filter_sources(source, root):
+            target = output_dir / source_file.name
+            if target.exists() and target.resolve() != source_file.resolve():
+                if mode == "error":
+                    raise FileExistsError(f"Filter name conflict while combining: {source_file.name}")
+                if mode == "rename":
+                    target = unique_filter_target(output_dir, source_file)
+
+            if target.resolve() != source_file.resolve():
+                shutil.copy2(source_file, target)
+            copied.append(target.name)
+
+    if not copied:
+        raise ValueError("No .dat filter files were found in the supplied inputs")
+
+    write_filter_index(output_dir, output_instrument)
+    return output_dir
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Combine filter sets into one MESA-compatible instrument"
+    )
+    parser.add_argument("output", help="Output name or Facility/Instrument path")
+    parser.add_argument("inputs", nargs="+", help="Filter-set directories or .dat files")
+    parser.add_argument("--base", default=str(FILTER_DIR_DEFAULT), help="Base filter directory")
+    parser.add_argument("--facility", default=None, help="Output facility label")
+    parser.add_argument("--instrument", default=None, help="Output instrument/index-file name")
+    parser.add_argument(
+        "--on-conflict",
+        choices=["rename", "overwrite", "error"],
+        default="rename",
+        help="How duplicate filter filenames are handled",
+    )
+
+    args = parser.parse_args(argv)
+    output_dir = combine_filter_sets(
+        args.output,
+        args.inputs,
+        filter_root=args.base,
+        facility=args.facility,
+        instrument=args.instrument,
+        on_conflict=args.on_conflict,
+    )
+    print(f"[filters] Combined filter set written to {output_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,10 +17,13 @@ def test_menu_valid_choices():
     from unittest.mock import patch
 
     for key, expected in [
-        ("1", "spectra"), ("2", "filters"), ("3", "rebuild"),
-        ("4", "combine"), ("5", "ml_completer"), ("6", "ml_generator"),
-        ("7", "grid_densifier"), ("8", "mesa_prepare"),
-        ("9", "config"), ("0", "quit"),
+        ("1", "filters"), ("2", "filters_combine"),
+        ("3", "spectra"), ("4", "rebuild"),
+        ("5", "combine"), ("6", "coverage"),
+        ("7", "import"), ("8", "grid_densifier"),
+        ("9", "ml_completer"), ("10", "ml_generator"),
+        ("11", "mesa_prepare"), ("12", "config"),
+        ("0", "quit"),
     ]:
         with patch("builtins.input", return_value=key):
             assert menu() == expected
@@ -53,3 +56,33 @@ def test_run_config_flow_no_change(capsys):
         run_config_flow()
     captured = capsys.readouterr()
     assert "Data directory" in captured.out
+
+
+def test_run_filter_combine_flow_wizard(tmp_path, capsys):
+    from sed_tools.cli import run_filter_combine_flow
+    from unittest.mock import patch
+
+    first = tmp_path / "GAIA" / "GAIA"
+    second = tmp_path / "2MASS" / "2MASS"
+    first.mkdir(parents=True)
+    second.mkdir(parents=True)
+    (first / "G.dat").write_text("Wavelength,Transmission\n1,1\n")
+    (second / "J.dat").write_text("Wavelength,Transmission\n2,1\n")
+
+    answers = iter([
+        "",       # use default base dir passed to flow
+        "1,2",    # select both local filter sets
+        "Gaia2MASS",
+        "",       # default facility Combined
+        "",       # default instrument/output name
+        "",       # default conflict mode rename
+        "",       # proceed
+    ])
+
+    with patch("builtins.input", side_effect=lambda _prompt="": next(answers)):
+        run_filter_combine_flow(base_dir=str(tmp_path))
+
+    out = tmp_path / "Combined" / "Gaia2MASS"
+    assert sorted(p.name for p in out.glob("*.dat")) == ["G.dat", "J.dat"]
+    assert (out / "Gaia2MASS").read_text().splitlines() == ["G.dat", "J.dat"]
+    assert "Combined 2 filters" in capsys.readouterr().out

--- a/tests/test_filter_api.py
+++ b/tests/test_filter_api.py
@@ -51,3 +51,47 @@ def test_remove_empty_filter_dir_keeps_real_filter_dir(tmp_path):
 
     assert path.exists()
     assert (path / "W1.dat").exists()
+
+
+def test_filters_combine_creates_mesa_index_file(tmp_path):
+    gaia = tmp_path / "GAIA" / "GAIA"
+    twomass = tmp_path / "2MASS" / "2MASS"
+    gaia.mkdir(parents=True)
+    twomass.mkdir(parents=True)
+    (gaia / "G.dat").write_text("Wavelength,Transmission\n5000,1\n")
+    (twomass / "J.dat").write_text("Wavelength,Transmission\n12000,1\n")
+
+    out = Filters.combine("Gaia2MASS", "GAIA/GAIA", "2MASS/2MASS", filter_root=tmp_path)
+
+    assert out == tmp_path / "Combined" / "Gaia2MASS"
+    assert sorted(p.name for p in out.glob("*.dat")) == ["G.dat", "J.dat"]
+    assert (out / "Gaia2MASS").read_text().splitlines() == ["G.dat", "J.dat"]
+
+
+def test_filters_combine_renames_conflicting_filter_names(tmp_path):
+    first = tmp_path / "A" / "Inst"
+    second = tmp_path / "B" / "Inst"
+    first.mkdir(parents=True)
+    second.mkdir(parents=True)
+    (first / "V.dat").write_text("Wavelength,Transmission\n1,1\n")
+    (second / "V.dat").write_text("Wavelength,Transmission\n2,1\n")
+
+    out = Filters.combine("Combined/AB", first, second, filter_root=tmp_path)
+
+    names = sorted(p.name for p in out.glob("*.dat"))
+    assert names == ["B_Inst_V.dat", "V.dat"]
+    assert (out / "AB").read_text().splitlines() == names
+
+
+def test_combine_filter_sets_module_function_matches_api_layout(tmp_path):
+    from sed_tools.combine_filters import combine_filter_sets
+
+    source = tmp_path / "Generic" / "Johnson"
+    source.mkdir(parents=True)
+    (source / "B.dat").write_text("Wavelength,Transmission\n1,1\n")
+
+    out = combine_filter_sets("Optical", ["Generic/Johnson"], filter_root=tmp_path)
+
+    assert out == tmp_path / "Combined" / "Optical"
+    assert (out / "B.dat").exists()
+    assert (out / "Optical").read_text().splitlines() == ["B.dat"]


### PR DESCRIPTION
### Motivation

- Provide a way to assemble multiple local photometric filter sets into a single MESA-compatible instrument/index without rebuilding spectra or flux cubes.

### Description

- Add a new module `sed_tools/combine_filters.py` implementing `find_filter_sets`, `combine_filter_sets`, and helper functions to resolve sources, handle name conflicts (`rename|overwrite|error`), and write MESA index files.
- Expose the feature through the public API as `Filters.combine(...)` in `sed_tools/api.py` and add a non-interactive CLI subcommand `filters-combine` in `sed_tools/cli.py` that calls `combine_filter_sets`.
- Add an interactive wizard `run_filter_combine_flow` and integrate it into the interactive `menu()` mapping and main loop in `sed_tools/cli.py`.
- Update `README.md` to document usage examples for the `sed-tools filters-combine` command and the Python API usage, and add a small import (`Path`) where needed.
- Add unit tests exercising the CLI wizard and API: new/updated tests in `tests/test_cli.py` and `tests/test_filter_api.py` to verify creation of the combined folder, index file, and conflict renaming behavior.

### Testing

- Ran the automated test suite with the new tests; the tests for the new functionality (`test_filters_combine_creates_mesa_index_file`, `test_filters_combine_renames_conflicting_filter_names`, `test_run_filter_combine_flow_wizard`, and `test_combine_filter_sets_module_function_matches_api_layout`) passed.
- Existing CLI/importability tests were executed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4573d42cc8832189fae291b920d625)