### PR TITLE
Reorder interactive CLI menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,11 +79,14 @@ sed-tools
 ### Direct Commands
 
 ```bash
-# Download stellar atmosphere spectra
-sed-tools spectra
-
 # Download photometric filter transmission curves
 sed-tools filters
+
+# Combine installed filter sets
+sed-tools filters-combine Gaia2MASS GAIA/GAIA 2MASS/2MASS
+
+# Download stellar atmosphere spectra
+sed-tools spectra
 
 # Build flux cubes and lookup tables from downloaded spectra
 sed-tools rebuild
@@ -101,44 +104,6 @@ sed-tools ml_generator
 ---
 
 ## CLI Reference
-
-### `sed-tools spectra`
-
-Download stellar atmosphere spectra from remote catalogs.
-
-```bash
-# Interactive source and model selection
-sed-tools spectra
-
-# Download specific models
-sed-tools spectra --models Kurucz2003all
-
-# Force a specific source
-sed-tools spectra --source svo --models Kurucz2003all
-
-# Parallel downloads
-sed-tools spectra --models Kurucz2003all --workers 8
-
-```
-
-**What it does:**
-
-1. Queries the selected source for available models
-2. Downloads spectrum files matching your criteria
-3. Standardizes units (wavelength → Å, flux → erg/cm²/s/Å)
-4. Generates `lookup_table.csv` with stellar parameters
-5. Automatically runs `rebuild` to create binary files
-
-**Sources:**
-
-| Source | Description |
-|--------|-------------|
-| `njm` | NJM server (default, fastest) |
-| `svo` | Spanish Virtual Observatory |
-| `msg` | MSG grids (Townsend) |
-| `mast` | MAST BOSZ library |
-
----
 
 ### `sed-tools filters`
 
@@ -178,6 +143,45 @@ from sed_tools.api import Filters
 combined = Filters.combine("Gaia2MASS", "GAIA/GAIA", "2MASS/2MASS")
 print(combined)
 ```
+
+---
+
+
+### `sed-tools spectra`
+
+Download stellar atmosphere spectra from remote catalogs.
+
+```bash
+# Interactive source and model selection
+sed-tools spectra
+
+# Download specific models
+sed-tools spectra --models Kurucz2003all
+
+# Force a specific source
+sed-tools spectra --source svo --models Kurucz2003all
+
+# Parallel downloads
+sed-tools spectra --models Kurucz2003all --workers 8
+
+```
+
+**What it does:**
+
+1. Queries the selected source for available models
+2. Downloads spectrum files matching your criteria
+3. Standardizes units (wavelength → Å, flux → erg/cm²/s/Å)
+4. Generates `lookup_table.csv` with stellar parameters
+5. Automatically runs `rebuild` to create binary files
+
+**Sources:**
+
+| Source | Description |
+|--------|-------------|
+| `njm` | NJM server (default, fastest) |
+| `svo` | Spanish Virtual Observatory |
+| `msg` | MSG grids (Townsend) |
+| `mast` | MAST BOSZ library |
 
 ---
 
@@ -536,6 +540,7 @@ info.covers_range(teff_min=5000, teff_max=6000)
 
 | CLI Command | Python API Equivalent |
 |-------------|----------------------|
+| `sed-tools filters` | `Filters.fetch(...)` |
 | `sed-tools spectra` (list) | `SED.query()` |
 | `sed-tools spectra --models X` | `SED.fetch('X')` |
 | `sed-tools rebuild --models X` | `sed.cat.write()` |
@@ -543,7 +548,6 @@ info.covers_range(teff_min=5000, teff_max=6000)
 | `sed-tools ml_completer train` | `SED.ml_completer().train(...)` |
 | `sed-tools ml_generator train` | `SED.ml_generator().train(...)` |
 | `sed-tools ml_generator generate` | `SED.ml_generator().generate(...)` |
-| `sed-tools filters` | `Filters.fetch(...)` |
 
 ---
 

--- a/api_usage.py
+++ b/api_usage.py
@@ -118,10 +118,28 @@ def ascii_sed_continuum(
 
 
 # =============================================================================
-# 1. Query available catalogs
+# 1. Filter profiles
+# =============================================================================
+print("\n" + "=" * 60)
+print("1. Filters.query() and Filters.fetch()")
+print("=" * 60)
+
+# Query local filters
+local_filters = Filters.query(include_remote=False)
+print(f"Local filter systems: {len(local_filters)}")
+for f in local_filters:
+    print(f"  {f['facility']}/{f['instrument']}: {f.get('n_filters', '?')} filters")
+
+# Fetch filters
+output = Filters.fetch('GAIA', 'GAIA')  # or 'LSST', 'LSST' or 'Generic', 'Johnson'
+print(f"\nDownloaded Johnson filters to: {output}")
+
+
+# =============================================================================
+# 2. Query available catalogs
 # =============================================================================
 print("=" * 60)
-print("1. SED.query() - Discover catalogs")
+print("2. SED.query() - Discover catalogs")
 print("=" * 60)
 
 # Query all (local + remote)
@@ -144,10 +162,10 @@ print(f"SVO remote catalogs: {len(svo_cats)}")
 
 
 # =============================================================================
-# 2. Fetch from remote
+# 3. Fetch from remote
 # =============================================================================
 print("\n" + "=" * 60)
-print("2. SED.fetch() - Download catalog")
+print("3. SED.fetch() - Download catalog")
 print("=" * 60)
 
 # Fetch with parameter filtering
@@ -167,10 +185,10 @@ print(f"logg grid: {sed.cat.logg_grid}")
 
 
 # =============================================================================
-# 3. Catalog operations
+# 4. Catalog operations
 # =============================================================================
 print("\n" + "=" * 60)
-print("3. Catalog operations")
+print("4. Catalog operations")
 print("=" * 60)
 
 # Access parameters as DataFrame
@@ -193,10 +211,10 @@ print(f"\nWrote catalog to: {output_path}")
 
 
 # =============================================================================
-# 4. Load local and interpolate
+# 5. Load local and interpolate
 # =============================================================================
 print("\n" + "=" * 60)
-print("4. SED.local() - Load and interpolate")
+print("5. SED.local() - Load and interpolate")
 print("=" * 60)
 
 sed = SED.local('Kurucz2003all')
@@ -226,10 +244,10 @@ print(f"  Wavelength range: {spectrum.wavelength[0]:.1f} - {spectrum.wavelength[
 
 
 # =============================================================================
-# 5. Combine catalogs
+# 6. Combine catalogs
 # =============================================================================
 print("\n" + "=" * 60)
-print("5. SED.combine() - Create ensemble grid")
+print("6. SED.combine() - Create ensemble grid")
 print("=" * 60)
 
 ensemble = SED.combine(
@@ -255,24 +273,6 @@ ascii_sed_continuum(spectrum.wavelength, spectrum.flux,
 
 output_path = ensemble.cat.write()
 print(f"\nWrote catalog to: {output_path}")
-
-
-# =============================================================================
-# 6. Filter profiles
-# =============================================================================
-print("\n" + "=" * 60)
-print("6. Filters.query() and Filters.fetch()")
-print("=" * 60)
-
-# Query local filters
-local_filters = Filters.query(include_remote=False)
-print(f"Local filter systems: {len(local_filters)}")
-for f in local_filters:
-    print(f"  {f['facility']}/{f['instrument']}: {f.get('n_filters', '?')} filters")
-
-# Fetch filters
-output = Filters.fetch('GAIA', 'GAIA')  # or 'LSST', 'LSST' or 'Generic', 'Johnson'
-print(f"\nDownloaded Johnson filters to: {output}")
 
 
 # =============================================================================

--- a/jupyter_notebooks/01_filters.ipynb
+++ b/jupyter_notebooks/01_filters.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# 08 — Photometric Filters\n",
+    "# 01 — Photometric Filters\n",
     "\n",
     "This notebook demonstrates how to download and manage photometric filter transmission curves. `Filters.fetch()` tries the NJM mirror first when it has the requested data, then falls back to the SVO Filter Profile Service.\n",
     "\n",

--- a/jupyter_notebooks/02_synthetic_photometry.ipynb
+++ b/jupyter_notebooks/02_synthetic_photometry.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# 09 — Synthetic Photometry\n",
+    "# 02 — Synthetic Photometry\n",
     "\n",
     "This notebook demonstrates how to compute synthetic magnitudes and fluxes from interpolated SEDs using the `photometry()` method.\n",
     "\n",
@@ -12,7 +12,7 @@
     "\n",
     "**Supported systems:** AB (default), Vega\n",
     "\n",
-    "Filter transmission curves must be installed first — see notebook 08."
+    "Filter transmission curves must be installed first — see notebook 01."
    ]
   },
   {

--- a/jupyter_notebooks/03_discovery_and_metadata.ipynb
+++ b/jupyter_notebooks/03_discovery_and_metadata.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# 01 — Discovery and Metadata\n",
+    "# 03 — Discovery and Metadata\n",
     "\n",
     "This notebook demonstrates how to discover available stellar atmosphere catalogs and inspect their metadata using the `SED_Tools` Python API.\n",
     "\n",

--- a/jupyter_notebooks/04_downloading_and_local_data.ipynb
+++ b/jupyter_notebooks/04_downloading_and_local_data.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# 02 — Downloading and Local Data\n",
+    "# 04 — Downloading and Local Data\n",
     "\n",
     "This notebook covers downloading stellar atmosphere spectra from remote sources and managing locally installed catalogs.\n",
     "\n",

--- a/jupyter_notebooks/05_interpolation.ipynb
+++ b/jupyter_notebooks/05_interpolation.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# 03 — Spectrum Interpolation\n",
+    "# 05 — Spectrum Interpolation\n",
     "\n",
     "This notebook demonstrates how to interpolate stellar spectra at arbitrary parameters using the flux cube.\n",
     "\n",

--- a/jupyter_notebooks/06_combining_grids.ipynb
+++ b/jupyter_notebooks/06_combining_grids.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# 04 — Combining Grids\n",
+    "# 06 — Combining Grids\n",
     "\n",
     "This notebook demonstrates how to merge multiple stellar atmosphere grids into a unified ensemble.\n",
     "\n",

--- a/jupyter_notebooks/07_ml_completion.ipynb
+++ b/jupyter_notebooks/07_ml_completion.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# 05 — ML SED Completion\n",
+    "# 07 — ML SED Completion\n",
     "\n",
     "This notebook demonstrates how to use the ML completer to extend incomplete SEDs to broader wavelength ranges.\n",
     "\n",

--- a/jupyter_notebooks/08_ml_generator.ipynb
+++ b/jupyter_notebooks/08_ml_generator.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# 06 — ML SED Generation\n",
+    "# 08 — ML SED Generation\n",
     "\n",
     "This notebook demonstrates the ML generator, which produces complete SEDs from stellar parameters alone — no input spectrum required.\n",
     "\n",

--- a/jupyter_notebooks/09_catalog_and_spectrum.ipynb
+++ b/jupyter_notebooks/09_catalog_and_spectrum.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# 07 — Catalog and Spectrum Objects\n",
+    "# 09 — Catalog and Spectrum Objects\n",
     "\n",
     "This notebook covers the core data structures of `SED_Tools`: the `Catalog` container and individual `Spectrum` objects.\n",
     "\n",

--- a/jupyter_notebooks/10_grid_densification.ipynb
+++ b/jupyter_notebooks/10_grid_densification.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# 11 — Grid Densification\n",
+    "# 10 — Grid Densification\n",
     "\n",
     "This notebook demonstrates the grid densifier, which fills in Teff gaps in a coarse flux cube to eliminate stair-stepping artefacts in MESA photometry.\n",
     "\n",

--- a/jupyter_notebooks/11_flux_cubes_and_mesa.ipynb
+++ b/jupyter_notebooks/11_flux_cubes_and_mesa.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# 10 — Flux Cubes and MESA Integration\n",
+    "# 11 — Flux Cubes and MESA Integration\n",
     "\n",
     "This notebook explains the `flux_cube.bin` binary format, how to read it directly, and how to wire the outputs into MESA's colors module.\n",
     "\n",

--- a/sed_tools/__init__.py
+++ b/sed_tools/__init__.py
@@ -494,17 +494,17 @@ def run_combine_flow(
 
 def menu() -> str:
     print("\nWhat would you like to run?")
-    print("  1) Spectra (NJM / SVO / MSG / MAST)")
-    print("  2) Filters (NJM / SVO)")
+    print("  1) Filters (NJM / SVO)")
+    print("  2) Spectra (NJM / SVO / MSG / MAST)")
     print("  3) Rebuild (lookup + HDF5 + flux cube)")
-    print("  4) Combine grids into omni grid")  # ← ADD THIS LINE
+    print("  4) Combine grids into omni grid")
     print("  0) Quit")
     choice = input("> ").strip()
     mapping = {
-        "1": "spectra", 
-        "2": "filters", 
+        "1": "filters",
+        "2": "spectra",
         "3": "rebuild",
-        "4": "combine",  # ← ADD THIS LINE
+        "4": "combine",
         "0": "quit"
     }
     return mapping.get(choice, "")

--- a/sed_tools/cli.py
+++ b/sed_tools/cli.py
@@ -1256,33 +1256,33 @@ def run_import_flow(base_dir: str = str(STELLAR_DIR_DEFAULT)) -> None:
 
 def menu() -> str:
     print("\nWhat would you like to run?")
-    print("1) Spectra (NJM / SVO / MSG / MAST)")
-    print("2) Filters (NJM / SVO)")
-    print("3) Rebuild (lookup + HDF5 + flux cube)")
-    print("4) Combine grids into omni grid")
-    print("5) ML SED Completer (train/extend incomplete SEDs)")
-    print("6) ML SED Generator (generate SEDs from parameters)")
-    print("7) Grid Densifier (fill coarse Teff gaps)")
-    print("8) MESA Prepare (export a sub-variant for MESA)")
-    print("9) Config (show/set data directory)")
-    print("10) Coverage (parameter-space summary + plot)")
-    print("11) Import a local grid into the pipeline")
-    print("12) Combine filter sets")
+    print("1) Filters (NJM / SVO)")
+    print("2) Combine filter sets")
+    print("3) Spectra (NJM / SVO / MSG / MAST)")
+    print("4) Rebuild (lookup + HDF5 + flux cube)")
+    print("5) Combine grids into omni grid")
+    print("6) ML SED Completer (train/extend incomplete SEDs)")
+    print("7) ML SED Generator (generate SEDs from parameters)")
+    print("8) Grid Densifier (fill coarse Teff gaps)")
+    print("9) Coverage (parameter-space summary + plot)")
+    print("10) Import a local grid into the pipeline")
+    print("11) MESA Prepare (export a sub-variant for MESA)")
+    print("12) Config (show/set data directory)")
     print("0) Quit")
     choice = input("> ").strip()
     mapping = {
-        "1": "spectra",
-        "2": "filters",
-        "3": "rebuild",
-        "4": "combine",
-        "5": "ml_completer",
-        "6": "ml_generator",
-        "7": "grid_densifier",
-        "8": "mesa_prepare",
-        "9": "config",
-        "10": "coverage",
-        "11": "import",
-        "12": "filters_combine",
+        "1": "filters",
+        "2": "filters_combine",
+        "3": "spectra",
+        "4": "rebuild",
+        "5": "combine",
+        "6": "ml_completer",
+        "7": "ml_generator",
+        "8": "grid_densifier",
+        "9": "coverage",
+        "10": "import",
+        "11": "mesa_prepare",
+        "12": "config",
         "0": "quit"
     }
     return mapping.get(choice, "")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,11 +17,11 @@ def test_menu_valid_choices():
     from unittest.mock import patch
 
     for key, expected in [
-        ("1", "spectra"), ("2", "filters"), ("3", "rebuild"),
-        ("4", "combine"), ("5", "ml_completer"), ("6", "ml_generator"),
-        ("7", "grid_densifier"), ("8", "mesa_prepare"),
-        ("9", "config"), ("10", "coverage"), ("11", "import"),
-        ("12", "filters_combine"), ("0", "quit"),
+        ("1", "filters"), ("2", "filters_combine"), ("3", "spectra"),
+        ("4", "rebuild"), ("5", "combine"), ("6", "ml_completer"),
+        ("7", "ml_generator"), ("8", "grid_densifier"),
+        ("9", "coverage"), ("10", "import"), ("11", "mesa_prepare"),
+        ("12", "config"), ("0", "quit"),
     ]:
         with patch("builtins.input", return_value=key):
             assert menu() == expected


### PR DESCRIPTION
### Motivation
- Make the interactive CLI more logical by surfacing filter-related actions first, followed by atmosphere/grid-related actions, and moving configuration/MESA items to the end.
- Keep the change minimal and only affect the interactive menu presentation and its numeric dispatch mapping.
- Preserve existing command names and behavior while changing only their ordering in the menu.

### Description
- Reordered the interactive menu text and numeric-to-command mapping in `sed_tools/cli.py` so filters and filter-combine options appear first, spectra and atmosphere/grid workflows follow, and config/MESA items are at the end.
- Applied the same minimal menu reorder to the package-level fallback menu in `sed_tools/__init__.py` to keep interactive behavior consistent.
- Updated the mapping keys so each numeric choice continues to dispatch to the same internal command names (e.g. `filters`, `filters_combine`, `spectra`, `rebuild`, `combine`, etc.).

### Testing
- Ran `python -m compileall sed_tools/cli.py sed_tools/__init__.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4590615c888321bb038837fe13cf0e)